### PR TITLE
Adds support for Arrays in the property helper

### DIFF
--- a/lib/convection/model/template/resource.rb
+++ b/lib/convection/model/template/resource.rb
@@ -17,9 +17,16 @@ module Convection
 
         class << self
           ## Class::property - Helper for adding property accessors
-          def property(accesor, name)
-            define_method(accesor) do |value|
-              property(name, value) ## Call Instance#property
+          def property(accesor, name, type=:string)
+            if type == :string
+              define_method(accesor) do |value|
+                property(name, value) ## Call Instance#property
+              end
+            elsif type == :array
+              define_method(accesor) do |value|
+                @properties[name] = [] if @properties[name].nil? || @properties[name].empty?
+                @properties[name] << value
+              end
             end
           end
         end


### PR DESCRIPTION
To use this with an array property do the following:

    property :vpc_security_groups, 'VPCSecurityGroups', :array

This will initialize `@properties['VPCSecurityGroups']` to an empty Array,
then adds elements to `@properties['VPCSecurityGroups']` as
`vpc_security_groups` is called within the dsl.