### PR TITLE
Tracking major internal refactoring effort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ mkmf.log
 
 keys
 VERSION
-convection-0.0.1.gem

--- a/convection.gemspec
+++ b/convection.gemspec
@@ -26,6 +26,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'aws-sdk', '>= 2'
   spec.add_runtime_dependency 'httparty', '~> 0.13'
-  spec.add_runtime_dependency 'netaddr', '~> 1.5'
   spec.add_runtime_dependency 'thor', '~> 0.19'
 end

--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -10,11 +10,15 @@ module Convection
       attr_reader :id
       attr_reader :name
       attr_accessor :template
+      attr_reader :exist
+      attr_reader :status
+      alias_method :exist?, :exist
 
       attr_reader :attributes
       attr_reader :errors
       attr_reader :options
       attr_reader :resources
+      attr_reader :attribute_mapping_values
       attr_reader :outputs
 
       ## AWS-SDK
@@ -55,13 +59,12 @@ module Convection
 
         @cloud = options.delete(:cloud)
         @cloud_name = options.delete(:cloud_name)
-
         @region = options.delete(:region) { |_| 'us-east-1' }
         @credentials = options.delete(:credentials)
         @parameters = options.delete(:parameters) { |_| {} } # Default empty hash
         @tags = options.delete(:tags) { |_| {} } # Default empty hash
-        @on_failure = options.delete(:on_failure) { |_| 'DELETE' }
         options.delete(:disable_rollback) # There can be only one...
+        @on_failure = options.delete(:on_failure) { |_| 'DELETE' }
         @capabilities = options.delete(:capabilities) { |_| ['CAPABILITY_IAM'] }
 
         @attributes = options.delete(:attributes) { |_| Model::Attributes.new }
@@ -74,13 +77,23 @@ module Convection
         @ec2_client = Aws::EC2::Client.new(client_options)
         @cf_client = Aws::CloudFormation::Client.new(client_options)
 
-        ## Get initial state
-        render
-        cf_get_stack(cloud_name)
-
-        ## Get last-seen event ID
+        ## Remote state
+        @exist = false
+        @status = NOT_CREATED
+        @id = nil
+        @outputs = {}
+        @resources = {}
+        @current_template = {}
         @last_event_seen = nil
-        cf_get_events(1) unless @id.nil?
+
+        ## Get initial state
+        get_status(cloud_name)
+        return unless exist?
+
+        get_resources
+        get_template
+        resource_attributes
+        get_events(1) # Get the latest page of events (Set @last_event_seen before starting)
       rescue Aws::Errors::ServiceError => e
         @errors << e
       end
@@ -91,6 +104,9 @@ module Convection
         "#{ cloud }-#{ name }"
       end
 
+      ##
+      # Attribute Accessors
+      ##
       def include?(stack, key = nil)
         return @attributes.include?(name, stack) if key.nil?
         @attributes.include?(stack, key)
@@ -108,14 +124,9 @@ module Convection
         @attributes.get(*args)
       end
 
-      def status
-        @remote.stack_status rescue NOT_CREATED
-      end
-
-      def exist?
-        !@remote.nil?
-      end
-
+      ##
+      # Stack State
+      ##
       def in_progress?
         [CREATE_IN_PROGRESS, ROLLBACK_IN_PROGRESS, DELETE_IN_PROGRESS,
          UPDATE_IN_PROGRESS, UPDATE_COMPLETE_CLEANUP_IN_PROGRESS,
@@ -140,14 +151,24 @@ module Convection
         !error? && complete?
       end
 
+      ##
+      # Rendderers
+      ##
       def render
-        template.render
+        @template.render
       end
 
       def to_json(pretty = false)
-        template.to_json(nil, pretty)
+        @template.to_json(nil, pretty)
       end
 
+      def diff
+        @template.diff(@current_template)
+      end
+
+      ##
+      # Controllers
+      ##
       def apply(&block)
         request_options = @options.clone.tap do |o|
           o[:template_body] = to_json
@@ -158,7 +179,7 @@ module Convection
         if exist?
           if diff.empty? ## No Changes. Just get resources and move on
             block.call(Model::Event.new(:complete, "Stack #{ name } has no changes", :info)) if block
-            cf_get_stack
+            get_status
             return
           end
 
@@ -175,31 +196,10 @@ module Convection
             o[:on_failure] = on_failure
           end)
 
-          cf_get_stack(cloud_name) # Get ID of new stack
+          get_status(cloud_name) # Get ID of new stack
         end
 
         watch(&block) if block # Block execution on stack status
-      rescue Aws::Errors::ServiceError => e
-        @errors << e
-      end
-
-      def diff
-        @template.diff(cf_get_template)
-      end
-
-      def watch(poll = 2, &block)
-        cf_get_stack
-
-        loop do
-          cf_get_events.reverse.each do |event|
-            block.call(Model::Event.from_cf(event))
-          end if block
-
-          break unless in_progress?
-
-          sleep poll
-          cf_get_stack
-        end
       rescue Aws::Errors::ServiceError => e
         @errors << e
       end
@@ -212,7 +212,24 @@ module Convection
         ## Block execution on stack status
         watch(&block) if block
 
-        cf_get_stack
+        get_status
+      rescue Aws::Errors::ServiceError => e
+        @errors << e
+      end
+
+      def watch(poll = 2, &block)
+        get_status
+
+        loop do
+          get_events.reverse.each do |event|
+            block.call(Model::Event.from_cf(event))
+          end if block
+
+          break unless in_progress?
+
+          sleep poll
+          get_status
+        end
       rescue Aws::Errors::ServiceError => e
         @errors << e
       end
@@ -233,41 +250,48 @@ module Convection
 
       private
 
-      def cf_get_stack(stack_name = id)
-        @remote = @cf_client.describe_stacks(:stack_name => stack_name).stacks.first
-        @id = @remote.stack_id
+      def get_status(stack_name = id)
+        cf_stack = @cf_client.describe_stacks(:stack_name => stack_name).stacks.first
 
-        @resources = {}
-        @cf_client.describe_stack_resources(:stack_name => @id).stack_resources.each do |resource|
-          next unless @template.attribute_mappings.include?(resource[:logical_resource_id])
+        @id = cf_stack.stack_id
+        @status = cf_stack.stack_status
+        @exist = true
 
-          attribute_map = @template.attribute_mappings[resource[:logical_resource_id]]
-          case attribute_map[:type].to_sym
-          when :string
-            @resources[attribute_map[:name]] = resource[:physical_resource_id]
-          when :array
-            @resources[attribute_map[:name]] = [] unless @resources[attribute_map[:name]].is_a?(Array)
-            @resources[attribute_map[:name]].push(resource[:physical_resource_id])
-          else
-            fail TypeError, "Attribute Mapping must be defined with type `string` or `array`, not #{ type }"
+        ## Parse outputs
+        @outputs = {}.tap do |collection|
+          cf_stack.outputs.each do |output|
+            collection[output[:output_key].to_s] = (JSON.parse(output[:output_value]) rescue output[:output_value])
           end
         end
 
-        @outputs = Hash[@remote.outputs.map do |output|
-          [output[:output_key].to_s, (JSON.parse(output[:output_value]) rescue output[:output_value])]
-        end]
-
         ## Add outputs to attribute set
-        @attributes.stack(self)
-
+        @attributes.load_outputs(self)
       rescue Aws::CloudFormation::Errors::ValidationError # Stack does not exist
-        @remote = nil
+        @exist = false
+        @status = NOT_CREATED
         @id = nil
-        @resources = {}
         @outputs = {}
       end
 
-      def cf_get_events(pages = nil, stack_name = id)
+      ## Fetch current resources
+      def get_resources
+        @resources = {}.tap do |collection|
+          @cf_client.describe_stack_resources(:stack_name => @id).stack_resources.each do |resource|
+            collection[resource[:logical_resource_id]] = resource
+          end
+        end
+      rescue Aws::CloudFormation::Errors::ValidationError # Stack does not exist
+        @resources = {}
+      end
+
+      def get_template
+        @current_template = JSON.parse(@cf_client.get_template(:stack_name => id).template_body)
+      rescue Aws::CloudFormation::Errors::ValidationError # Stack does not exist
+        @current_template = {}
+      end
+
+      ## Fetch new stack events
+      def get_events(pages = nil, stack_name = id)
         return [] unless exist?
 
         [].tap do |collection|
@@ -291,8 +315,28 @@ module Convection
       rescue Aws::CloudFormation::Errors::ValidationError # Stack does not exist
       end
 
-      def cf_get_template
-        JSON.parse(@cf_client.get_template(:stack_name => id).template_body)
+      ## TODO No. This will become unnecessary as current_state is fleshed out
+      def resource_attributes
+        @attribute_mapping_values = {}
+        @template.execute ## Populate mappings fro the template
+
+        @resources.each do |logical, resource|
+          next unless @template.attribute_mappings.include?(logical)
+
+          attribute_map = @template.attribute_mappings[logical]
+          case attribute_map[:type].to_sym
+          when :string
+            @attribute_mapping_values[attribute_map[:name]] = resource[:physical_resource_id]
+          when :array
+            @attribute_mapping_values[attribute_map[:name]] = [] unless @resources[attribute_map[:name]].is_a?(Array)
+            @attribute_mapping_values[attribute_map[:name]].push(resource[:physical_resource_id])
+          else
+            fail TypeError, "Attribute Mapping must be defined with type `string` or `array`, not #{ type }"
+          end
+        end
+
+        ## Add mapped resource IDs to attributes
+        @attributes.load_resources(self)
       end
 
       def cf_parameters

--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -328,7 +328,7 @@ module Convection
           when :string
             @attribute_mapping_values[attribute_map[:name]] = resource[:physical_resource_id]
           when :array
-            @attribute_mapping_values[attribute_map[:name]] = [] unless @resources[attribute_map[:name]].is_a?(Array)
+            @attribute_mapping_values[attribute_map[:name]] = [] unless @attribute_mapping_values[attribute_map[:name]].is_a?(Array)
             @attribute_mapping_values[attribute_map[:name]].push(resource[:physical_resource_id])
           else
             fail TypeError, "Attribute Mapping must be defined with type `string` or `array`, not #{ type }"

--- a/lib/convection/dsl/helpers.rb
+++ b/lib/convection/dsl/helpers.rb
@@ -22,17 +22,6 @@ module Convection
           collection
         end
       end
-
-      # def child(child_name, klass, options = {}, &block)
-      #   attr_reader collection
-      #   define_method(child_name) do |instance_name, &instance_block|
-      #     resource = klass.new(instance_name, self)
-      #     resource.instance_exec(&instance_block) if instance_block
-      #
-      #     instance_exec(resource, &block) if block
-      #     instance_variable_get("@#{ options[:collection] }")[instance_name] = resource if options.include?(:collection)
-      #   end
-      # end
     end
 
     ##
@@ -47,6 +36,13 @@ module Convection
       class << self
         def included(mod)
           mod.extend(DSL::ClassHelpers)
+        end
+
+        def method_name(cf_type)
+          nodes = cf_type.split('::')
+          nodes.shift # Remove AWS::
+
+          nodes.join('_').downcase
         end
       end
 

--- a/lib/convection/dsl/helpers.rb
+++ b/lib/convection/dsl/helpers.rb
@@ -42,6 +42,11 @@ module Convection
           nodes = cf_type.split('::')
           nodes.shift # Remove AWS::
 
+          ## Cammel-case to snake-case
+          nodes.map! do |n|
+            n.split(/([A-Z0-9])(?![A-Z0-9])(?<!$)/).reject(&:empty?).reduce('') { |a, e| (e.length == 1 && !a.empty?) ? a += "_#{e}" : a += e }.downcase
+          end
+
           nodes.join('_').downcase
         end
       end

--- a/lib/convection/model/attributes.rb
+++ b/lib/convection/model/attributes.rb
@@ -48,9 +48,12 @@ module Convection
         @stacks[stack.to_s][key.to_s] = value
       end
 
-      def stack(stack)
-        @stacks[stack.name.to_s].resources = stack.resources
+      def load_outputs(stack)
         @stacks[stack.name.to_s].outputs = stack.outputs
+      end
+
+      def load_resources(stack)
+        @stacks[stack.name.to_s].resources = stack.attribute_mapping_values
       end
     end
   end

--- a/lib/convection/model/mixin/cidr_block.rb
+++ b/lib/convection/model/mixin/cidr_block.rb
@@ -4,12 +4,14 @@ module Convection
   module Model
     module Mixin
       ##
-      # Add condition helpers
+      # Sanitized CIDR IP notation
       ##
       module CIDRBlock
-        def network(*args)
-          @network = NetAddr::CIDR.create(*args) unless args.empty?
-          property('CidrBlock', @network.to_s)
+        def cidr_property(name = :network, property_name = 'CidrBlock')
+          property(name, property_name,
+                   :transform => proc { |*args|
+                     NetAddr::CIDR.create(*args)
+                   })
         end
       end
     end

--- a/lib/convection/model/mixin/conditional.rb
+++ b/lib/convection/model/mixin/conditional.rb
@@ -11,9 +11,7 @@ module Convection
         end
 
         def render_condition(resource)
-          resource.tap do |r|
-            r['Condition'] = condition unless condition.nil?
-          end
+          resource['Condition'] = condition.render unless condition.nil?
         end
       end
     end

--- a/lib/convection/model/mixin/protocol.rb
+++ b/lib/convection/model/mixin/protocol.rb
@@ -7,22 +7,21 @@ module Convection
       # Map IP protocol names to numbers
       ##
       module Protocol
-        def protocol_property(name = :protocol)
-          attr_reader name
-
-          writer = proc do |value = nil|
-            instance_variable_set("@#{ name }", case value
-                                                when :any then -1
-                                                when :icmp then 1
-                                                when :tcp then 6
-                                                when :udp then 17
-                                                else value
-            end) unless value.nil?
-            instance_variable_get("@#{ name }")
+        class << self
+          def lookup(value)
+            case value
+            when :any then -1
+            when :icmp then 1
+            when :tcp then 6
+            when :udp then 17
+            else value
+            end
           end
+        end
 
-          define_method(name, &writer)
-          define_method("#{name}=", &writer)
+        def protocol_property(name = :protocol, property_name = 'IpProtocol')
+          property(name, property_name,
+                   :transform => Mixin::Protocol.method(:lookup))
         end
       end
     end

--- a/lib/convection/model/template/condition.rb
+++ b/lib/convection/model/template/condition.rb
@@ -6,14 +6,15 @@ module Convection
       class Condition
         include DSL::Helpers
 
-        CONDITIONAL_FUNCTION_SYNTAX_MAP = 
-          { fn_and: 'Fn::And', 
+        CONDITIONAL_FUNCTION_SYNTAX_MAP =
+          { fn_and: 'Fn::And',
             fn_equals: 'Fn::Equals',
-            fn_if: 'Fn::If', 
-            fn_not: 'Fn::Not', 
+            fn_if: 'Fn::If',
+            fn_not: 'Fn::Not',
             fn_or: 'Fn::Or' }
 
         attr_reader :condition
+        attr_reader :template
 
         CONDITIONAL_FUNCTION_SYNTAX_MAP.keys.each do |conditional_function|
           define_method(conditional_function) do |*args|
@@ -21,9 +22,9 @@ module Convection
           end
         end
 
-        def initialize(name, template)
+        def initialize(name, parent)
           @name = name
-          @template = template
+          @template = parent.template
         end
 
         def render

--- a/lib/convection/model/template/mapping.rb
+++ b/lib/convection/model/template/mapping.rb
@@ -21,10 +21,11 @@ module Convection
         include DSL::Helpers
 
         attr_reader :items
+        attr_reader :template
 
-        def initialize(name, template)
+        def initialize(name, parent)
           @name = name
-          @template = template
+          @template = parent.template
 
           @items = Smash.new
         end

--- a/lib/convection/model/template/output.rb
+++ b/lib/convection/model/template/output.rb
@@ -15,10 +15,11 @@ module Convection
         attribute :name
         attribute :value
         attribute :description
+        attr_reader :template
 
-        def initialize(name, template)
+        def initialize(name, parent)
           @name = name
-          @template = template
+          @template = parent.template
 
           @type = ''
           @properties = {}

--- a/lib/convection/model/template/output.rb
+++ b/lib/convection/model/template/output.rb
@@ -27,7 +27,7 @@ module Convection
 
         def render
           {
-            'Value' => value.is_a?(Array) ? JSON.generate(value) : value,
+            'Value' => value.respond_to?(:render) ? value.render : value,
             'Description' => description
           }.tap do |output|
             render_condition(output)

--- a/lib/convection/model/template/parameter.rb
+++ b/lib/convection/model/template/parameter.rb
@@ -12,6 +12,7 @@ module Convection
         attribute :type
         attribute :default
         attribute :description
+        attr_reader :template
 
         attr_reader :allowed_values
         attribute :allowed_pattern
@@ -22,9 +23,9 @@ module Convection
         attribute :min_value
         attribute :constraint_description
 
-        def initialize(name, template)
+        def initialize(name, parent)
           @name = name
-          @template = template
+          @template = parent.template
 
           @type = 'String'
           @default = ''

--- a/lib/convection/model/template/resource.rb
+++ b/lib/convection/model/template/resource.rb
@@ -13,59 +13,248 @@ module Convection
       # Resource
       ##
       class Resource
+        class << self
+          def properties
+            @properties ||= {}
+          end
+
+          def type(cf_type = nil)
+            return @type if cf_type.nil?
+
+            @type = cf_type
+            @name = DSL::Helpers.method_name(cf_type)
+
+            DSL::Template::Resource.attach_resource(@name, self)
+          end
+
+          def property(accesor, property_name, options = {})
+            ## Handle usage of old property interface
+            options = {}.tap do |o|
+              o[:type] = options
+            end if options.is_a?(Symbol)
+
+            properties[accesor] = Property.create(accesor, property_name, options)
+            properties[accesor].attach(self)
+          end
+
+          def attach_method(name, &block)
+            define_method(name, &block)
+          end
+        end
 
         ##
-        # Helpers for defining Resource DSLs
+        # Validation and intraspection for resource properties
         ##
-        module Helpers
-          def property(accesor, property_name, type = :string)
-            case type.to_sym
-            when :string
-              define_method(accesor) do |value = nil|
-                ## Call Instance#property
-                return property(property_name) if value.nil?
-                property(property_name, value)
-              end
+        class Property
+          attr_reader :name
+          attr_reader :property_name
+          attr_reader :default
+          attr_reader :transform
 
-              define_method("#{ accesor }=") do |value|
-                ## Call Instance#property
-                property(property_name, value)
-              end
-            when :array
-              define_method(accesor) do |*value|
-                @properties[property_name] = [] unless @properties[property_name].is_a?(Array)
-                @properties[property_name].push(*value.flatten.map do |entity|
-                  entity.is_a?(Resource) ? entity.reference : entity
-                end)
+          attr_reader :immutable
+          alias_method :immutable?, :immutable
+          attr_reader :required
+          attr_reader :equal_to
+          attr_reader :kind_of
+          attr_reader :regex
 
-                @properties[property_name]
+          class << self
+            ## Switch between Scalar and List
+            def create(name, property_name, options = {})
+              case options[:type]
+              when :string, :scalar, nil then ScalarProperty.new(name, property_name, options)
+              when :array, :list then ListProperty.new(name, property_name, options)
+              else fail TypeError, "Property must be defined with type `string` or `array`, not #{ options[:type] }"
               end
-            else
-              fail TypeError, "Property must be defined with type `string` or `array`, not #{ type }"
+            end
+          end
+
+          def initialize(name, property_name, options = {})
+            @name = name
+            @property_name = property_name
+            @default = options[:default]
+            @transform = options.fetch(:transform, []).is_a?(Array) ? options.fetch(:transform, []) : [options[:transform]]
+
+            @immutable = options[:immutable].is_a?(TrueClass)
+            @required = options.fetch(:required, false)
+            @equal_to = options.fetch(:equal_to, []).is_a?(Array) ? options.fetch(:equal_to, []) : [options[:equal_to]]
+            @kind_of = options.fetch(:kind_of, []).is_a?(Array) ? options.fetch(:kind_of, []) : [options[:kind_of]]
+            @regex = options.fetch(:regex, false)
+          end
+        end
+
+        ##
+        # An instance of a poperty in a resoruce
+        ##
+        class PropertyInstance
+          attr_reader :resource
+          attr_reader :property
+          attr_reader :value
+          attr_accessor :current_value
+
+          def initialize(resource, property = nil)
+            @resource = resource
+            @property = property
+          end
+
+          def transform(value)
+            return value if property.nil?
+            property.transform.inject(value) { |a, e| e.call(a) }
+          end
+
+          def validate!(value)
+            return value if property.nil?
+
+            if resource.exist? && property.immutable && current_value != value
+              fail ArgumentError,
+                   "Property #{ property.name } is immutable!"
+            end
+
+            if property.required && value.nil?
+              fail ArgumentError,
+                   "Property #{ property.name } is required!"
+            end
+
+            unless property.equal_to.empty? || property.equal_to.include?(value)
+              fail ArgumentError,
+                   "Property #{ property.name } must be one of #{ property.equal_to.join(', ') }!"
+            end
+
+            unless property.kind_of.empty? || property.kind_of.any? { |t| value.is_a?(t) }
+              fail ArgumentError,
+                   "Property #{ property.name } must be one of #{ property.kind_of.join(', ') }!"
+            end
+
+            unless !property.regex || property.regex.match(value.to_s)
+              fail ArgumentError,
+                   "Property #{ property.name } must match #{ property.regex.inspect }!"
+            end
+
+            value
+          end
+
+          def current(val)
+            @current_value = @value = val
+          end
+        end
+
+        ##
+        # A Scalar Property
+        ##
+        class ScalarProperty < Property
+          def attach(resource)
+            definition = self ## Expose to resource instance closure
+
+            resource.attach_method(definition.name) do |value = nil|
+              return properties[definition.property_name].value if value.nil?
+              properties[definition.property_name].value = value
+            end
+
+            resource.attach_method("#{ definition.name }=") do |value|
+              properties[definition.property_name].value = value
+            end
+          end
+
+          def instance(resource)
+            ScalarPropertyInstance.new(resource, self)
+          end
+        end
+
+        ##
+        # Instance of a scalar property
+        ##
+        class ScalarPropertyInstance < PropertyInstance
+          def value=(update)
+            @value = validate!(transform(update))
+          end
+
+          def render
+            value.is_a?(Resource) ? value.reference : value
+          end
+        end
+
+        ##
+        # A List Property
+        ##
+        class ListProperty < Property
+          def attach(resource)
+            definition = self ## Expose to resource instance closure
+
+            resource.attach_method(definition.name) do |*values|
+              properties[definition.property_name].push(*values.flatten) unless values.empty?
+
+              ## Return the list
+              properties[definition.property_name].value
+            end
+          end
+
+          def instance(resource)
+            ListPropertyInstance.new(resource, self)
+          end
+        end
+
+        ##
+        # Instance of a list property
+        ##
+        class ListPropertyInstance < PropertyInstance
+          def initialize(*_)
+            super
+
+            @value = []
+            @current_value = []
+          end
+
+          def push(*values)
+            values.map! do |val|
+              validate!(val)
+              transform(val)
+            end
+
+            @value.push(*values)
+          end
+          alias_method :<<, :push
+
+          def render
+            value.map do |val|
+              val.is_a?(Resource) ? val.reference : val
             end
           end
         end
 
         include DSL::Helpers
         include Model::Mixin::Conditional
-        extend Resource::Helpers
 
+        ##
+        # Resource Instance Methods
+        ##
         attribute :type
         attr_reader :name
+        attr_reader :template
         attr_reader :properties
+        attr_reader :exist
+        alias_method :exist?, :exist
 
-        def initialize(name, template)
+        def initialize(name, parent)
           @name = name
-          @template = template
-
-          @type = ''
-          @properties = {}
+          @template = parent.template
+          @type = self.class.type
           @depends_on = []
+          @exist = false
+
+          ## Instantiate properties
+          @properties = Model::Collection.new
+          resource = self
+          resource.class.properties.each do |_, property|
+            @properties[property.property_name] = property.instance(resource)
+          end
         end
 
         def property(key, value = nil)
-          return properties[key] if value.nil?
-          properties[key] = value.is_a?(Resource) ? value.reference : value
+          return properties[key].value if value.nil?
+
+          ## Define a property instance on the fly
+          properties[key] = ScalarPropertyInstance.new(self) unless properties.include?(key)
+          properties[key].value = value
         end
 
         def depends_on(resource)
@@ -97,7 +286,7 @@ module Convection
         def render
           {
             'Type' => type,
-            'Properties' => properties
+            'Properties' => properties.map(true, &:render)
           }.tap do |resource|
             resource['DependsOn'] = @depends_on unless @depends_on.empty?
             render_condition(resource)
@@ -108,6 +297,7 @@ module Convection
   end
 end
 
-# Require all resource files
-resources_dir = File.join(File.dirname(File.absolute_path(__FILE__)), 'resource')
-Dir.glob( File.join( resources_dir, '*.rb'), &method(:require))
+## Require all resources
+Dir.glob(File.expand_path('../resource/*.rb', __FILE__)) do |r|
+  require_relative r
+end

--- a/lib/convection/model/template/resource/aws_auto_scaling_auto_scaling_group.rb
+++ b/lib/convection/model/template/resource/aws_auto_scaling_auto_scaling_group.rb
@@ -10,6 +10,7 @@ module Convection
         class AutoScalingGroup < Resource
           include Model::Mixin::Taggable
 
+          type 'AWS::AutoScaling::AutoScalingGroup'
           property :availability_zone, 'AvailabilityZones', :array
           property :cooldown, 'Cooldown'
           property :desired_capacity, 'DesiredCapacity'
@@ -26,29 +27,12 @@ module Convection
           property :termination_policie, 'TerminationPolicies', :array
           property :vpc_zone_identifier, 'VPCZoneIdentifier', :array
 
-          def initialize(*args)
-            super
-            type 'AWS::AutoScaling::AutoScalingGroup'
-          end
-
           def render(*args)
             super.tap do |resource|
               render_tags(resource)
             end
           end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def autoscaling_group(name, &block)
-        r = Model::Template::Resource::AutoScalingGroup.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_auto_scaling_launch_configuration.rb
+++ b/lib/convection/model/template/resource/aws_auto_scaling_launch_configuration.rb
@@ -8,7 +8,7 @@ module Convection
         # AWS::AutoScaling::LaunchConfiguration
         ##
         class LaunchConfiguration < Resource
-
+          type 'AWS::AutoScaling::LaunchConfiguration'
           property :associate_public_ip_address, 'AssociatePublicIpAddress'
           property :block_device_mappings, 'BlockDeviceMappings', :array
           property :ebs_optimized, 'EbsOptimized'
@@ -23,24 +23,7 @@ module Convection
           property :security_group, 'SecurityGroups', :array
           property :spot_price, 'SpotPrice'
           property :user_data, 'UserData'
-
-          def initialize(*args)
-            super
-            type 'AWS::AutoScaling::LaunchConfiguration'
-          end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def launch_configuration(name, &block)
-        r = Model::Template::Resource::LaunchConfiguration.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_auto_scaling_scaling_policy.rb
+++ b/lib/convection/model/template/resource/aws_auto_scaling_scaling_policy.rb
@@ -8,29 +8,12 @@ module Convection
         # AWS::AutoScaling::ScalingPolicy
         ##
         class ScalingPolicy < Resource
-
+          type 'AWS::AutoScaling::ScalingPolicy'
           property :adjustment_type, 'AdjustmentType'
           property :auto_scaling_group_name, 'AutoScalingGroupName'
           property :cooldown, 'Cooldown'
           property :scaling_adjustment, 'ScalingAdjustment'
-
-          def initialize(*args)
-            super
-            type 'AWS::AutoScaling::ScalingPolicy'
-          end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def parameter_group(name, &block)
-        r = Model::Template::Resource::ScalingPolicy.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_cloud_watch_alarm.rb
+++ b/lib/convection/model/template/resource/aws_cloud_watch_alarm.rb
@@ -8,41 +8,23 @@ module Convection
         # AWS::CloudWatch::Alarm
         ##
         class CloudWatchAlarm < Resource
-          property :actions_enabled, 'ActionsEnabled'
-          property :alarm_action, 'AlarmActions', :array
+          type 'AWS::CloudWatch::Alarm'
+          property :actions_enabled, 'ActionsEnabled', :default => true
+          property :alarm_action, 'AlarmActions', :type => :list
           property :alarm_description, 'AlarmDescription'
           property :alarm_name, 'AlarmName'
           property :comparison_operator, 'ComparisonOperator'
-          property :dimension, 'Dimensions', :array
+          property :dimension, 'Dimensions', :type => :list
           property :evaluation_periods, 'EvaluationPeriods'
-          property :insufficient_data_action, 'InsufficientDataActions', :array
+          property :insufficient_data_action, 'InsufficientDataActions', :type => :list
           property :metric_name, 'MetricName'
           property :namespace, 'Namespace'
-          property :ok_action, 'OKActions', :array
+          property :ok_action, 'OKActions', :type => :list
           property :period, 'Period'
           property :statistic, 'Statistic'
           property :threshold, 'Threshold'
           property :unit, 'Unit'
-
-          def initialize(*args)
-            super
-            type 'AWS::CloudWatch::Alarm'
-
-            @properties['ActionsEnabled'] = true
-          end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def cloud_watch_alarm(name, &block)
-        r = Model::Template::Resource::CloudWatchAlarm.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_ec2_instance.rb
+++ b/lib/convection/model/template/resource/aws_ec2_instance.rb
@@ -10,24 +10,15 @@ module Convection
         class EC2Instance < Resource
           include Model::Mixin::Taggable
 
+          type 'AWS::EC2::Instance'
           property :availability_zone, 'AvailabilityZone'
           property :image_id, 'ImageId'
           property :instance_type, 'InstanceType'
           property :key_name, 'KeyName'
           property :subnet, 'SubnetId'
           property :user_data, 'UserData'
-
-          def initialize(*args)
-            super
-
-            type 'AWS::EC2::Instance'
-            @properties['SecurityGroupIds'] = []
-          end
-
-          ## Accumulate SecurityGroups
-          def security_group(value)
-            @properties['SecurityGroupIds'] << value
-          end
+          property :security_group, 'SecurityGroupIds', :type => :list
+          property :src_dst_checks, 'SourceDestCheck'
 
           def render(*args)
             super.tap do |resource|
@@ -35,18 +26,6 @@ module Convection
             end
           end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def ec2_instance(name, &block)
-        r = Model::Template::Resource::EC2Instance.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_ec2_internet_gateway.rb
+++ b/lib/convection/model/template/resource/aws_ec2_internet_gateway.rb
@@ -2,18 +2,11 @@ require_relative '../resource'
 
 module Convection
   module DSL
-    ## Add DSL method to template namespace
     module Template
-      def ec2_internet_gateway(name, &block)
-        r = Model::Template::Resource::EC2InternetGateway.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
-      end
-
       module Resource
         ##
         # Add DSL for VPCGatewayAttachment
+        ##
         module EC2InternetGateway
           def attach_to_vpc(vpc, &block)
             a = Model::Template::Resource::EC2VPCGatewayAttachment.new("#{ name }VPCAttachment#{ vpc.name }", self)
@@ -37,11 +30,7 @@ module Convection
         class EC2InternetGateway < Resource
           include Model::Mixin::Taggable
           include DSL::Template::Resource::EC2InternetGateway
-
-          def initialize(*args)
-            super
-            type 'AWS::EC2::InternetGateway'
-          end
+          type 'AWS::EC2::InternetGateway'
 
           def render(*args)
             super.tap do |resource|

--- a/lib/convection/model/template/resource/aws_ec2_network_acl.rb
+++ b/lib/convection/model/template/resource/aws_ec2_network_acl.rb
@@ -2,15 +2,7 @@ require_relative '../resource'
 
 module Convection
   module DSL
-    ## Add DSL method to template namespace
     module Template
-      def ec2_network_acl(name, &block)
-        r = Model::Template::Resource::EC2NetworkACL.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
-      end
-
       module Resource
         ##
         # Add DSL helpers to EC2NetworkACL
@@ -38,12 +30,8 @@ module Convection
           include DSL::Template::Resource::EC2NetworkACL
           include Model::Mixin::Taggable
 
+          type 'AWS::EC2::NetworkAcl'
           property :vpc, 'VpcId'
-
-          def initialize(*args)
-            super
-            type 'AWS::EC2::NetworkAcl'
-          end
 
           def render(*args)
             super.tap do |resource|

--- a/lib/convection/model/template/resource/aws_ec2_network_acl_entry.rb
+++ b/lib/convection/model/template/resource/aws_ec2_network_acl_entry.rb
@@ -8,40 +8,19 @@ module Convection
         # AWS::EC2::NetworkACL
         ##
         class EC2NetworkACLEntry < Resource
-          include Model::Mixin::CIDRBlock
-          extend Model::Mixin::Protocol
+          extend Mixin::CIDRBlock
+          extend Mixin::Protocol
 
+          type 'AWS::EC2::NetworkAclEntry'
           property :acl, 'NetworkAclId'
           property :action, 'RuleAction'
           property :number, 'RuleNumber'
           property :egress, 'Egress'
           property :icmp, 'Icmp'
           property :range, 'PortRange'
-          protocol_property
-
-          def initialize(*args)
-            super
-            type 'AWS::EC2::NetworkAclEntry'
-          end
-
-          def render(*args)
-            super.tap do |resource|
-              resource['Properties']['Protocol'] = protocol # From protocol_property
-            end
-          end
+          cidr_property :network, 'CidrBlock'
+          protocol_property :protocol, 'Protocol'
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def ec2_network_acl(name, &block)
-        r = Model::Template::Resource::EC2NetworkACL.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_ec2_route.rb
+++ b/lib/convection/model/template/resource/aws_ec2_route.rb
@@ -8,30 +8,14 @@ module Convection
         # AWS::EC2::Route
         ##
         class EC2Route < Resource
+          type 'AWS::EC2::Route'
           property :route_table_id, 'RouteTableId'
           property :destination, 'DestinationCidrBlock'
           property :gateway, 'GatewayId'
           property :instance, 'InstanceId'
           property :interface, 'NetworkInterfaceId'
           property :peer, 'VpcPeeringConnectionId'
-
-          def initialize(*args)
-            super
-            type 'AWS::EC2::Route'
-          end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def ec2_route(name, &block)
-        r = Model::Template::Resource::EC2Route.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_ec2_route_table.rb
+++ b/lib/convection/model/template/resource/aws_ec2_route_table.rb
@@ -3,15 +3,7 @@ require_relative '../resource'
 module Convection
 
   module DSL
-    ## Add DSL method to template namespace
     module Template
-      def ec2_route_table(name, &block)
-        r = Model::Template::Resource::EC2RouteTable.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
-      end
-
       module Resource
         ##
         # DSL For routes
@@ -39,12 +31,8 @@ module Convection
           include DSL::Template::Resource::EC2RouteTable
           include Model::Mixin::Taggable
 
+          type 'AWS::EC2::RouteTable'
           property :vpc, 'VpcId'
-
-          def initialize(*args)
-            super
-            type 'AWS::EC2::RouteTable'
-          end
 
           def render(*args)
             super.tap do |resource|

--- a/lib/convection/model/template/resource/aws_ec2_security_group_ingres.rb
+++ b/lib/convection/model/template/resource/aws_ec2_security_group_ingres.rb
@@ -1,0 +1,25 @@
+require_relative '../resource'
+
+module Convection
+  module Model
+    class Template
+      class Resource
+        ##
+        # AWS::EC2::SecurityGroup
+        ##
+        class EC2SecurityGroupIngres < Resource
+          extend Mixin::Protocol
+
+          type 'AWS::EC2::SecurityGroupIngress'
+          property :address, 'CidrIp'
+          property :parent, 'GroupId'
+          property :from, 'FromPort'
+          property :to, 'ToPort'
+          protocol_property :protocol, 'IpProtocol'
+          property :source_group, 'SourceSecurityGroupId'
+          property :source_owner, 'SourceSecurityGroupOwnerId'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource/aws_ec2_subnet.rb
+++ b/lib/convection/model/template/resource/aws_ec2_subnet.rb
@@ -4,21 +4,14 @@ require_relative 'aws_ec2_subnet_route_table_association'
 module Convection
 
   module DSL
-    ## Add DSL method to template namespace
     module Template
-      def ec2_subnet(name, &block)
-        r = Model::Template::Resource::EC2Subnet.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
-      end
-
       module Resource
         ##
         # Add DSL for RouteTableAssocaition
+        ##
         module EC2Subnet
           def route_table(table, &block)
-            assoc = Model::Template::Resource::EC2SubnetRouteTableAssociation.new("#{ name }RouteTableAssociation#{ table.name }", @tamplate)
+            assoc = Model::Template::Resource::EC2SubnetRouteTableAssociation.new("#{ name }RouteTableAssociation#{ table.name }", template)
             assoc.route_table(table)
             assoc.subnet(self)
 
@@ -27,7 +20,7 @@ module Convection
           end
 
           def acl(acl_entity, &block)
-            assoc = Model::Template::Resource::EC2SubnetNetworkACLAssociation.new("#{ name }ACLAssociation#{ acl_entity.name }", self)
+            assoc = Model::Template::Resource::EC2SubnetNetworkACLAssociation.new("#{ name }ACLAssociation#{ acl_entity.name }", template)
             assoc.acl(acl_entity)
             assoc.subnet(self)
 
@@ -47,16 +40,13 @@ module Convection
         ##
         class EC2Subnet < Resource
           include DSL::Template::Resource::EC2Subnet
-          include Model::Mixin::CIDRBlock
           include Model::Mixin::Taggable
+          extend Mixin::CIDRBlock
 
+          type 'AWS::EC2::Subnet'
           property :availability_zone, 'AvailabilityZone'
           property :vpc, 'VpcId'
-
-          def initialize(*args)
-            super
-            type 'AWS::EC2::Subnet'
-          end
+          cidr_property :network, 'CidrBlock'
 
           def render(*args)
             super.tap do |resource|

--- a/lib/convection/model/template/resource/aws_ec2_subnet_network_acl_association.rb
+++ b/lib/convection/model/template/resource/aws_ec2_subnet_network_acl_association.rb
@@ -8,26 +8,10 @@ module Convection
         # AWS::EC2::SubnetRouteTableAssociation
         ##
         class EC2SubnetNetworkACLAssociation < Resource
+          type 'AWS::EC2::SubnetNetworkAclAssociation'
           property :acl, 'NetworkAclId'
           property :subnet, 'SubnetId'
-
-          def initialize(*args)
-            super
-            type 'AWS::EC2::SubnetNetworkAclAssociation'
-          end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def ec2_subnet_network_acl_association(name, &block)
-        assoc = Model::Template::Resource::EC2SubnetNetworkACLAssociation.new(name, self)
-
-        assoc.instance_exec(&block) if block
-        resources[name] = assoc
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_ec2_subnet_route_table_association.rb
+++ b/lib/convection/model/template/resource/aws_ec2_subnet_route_table_association.rb
@@ -8,26 +8,10 @@ module Convection
         # AWS::EC2::SubnetRouteTableAssociation
         ##
         class EC2SubnetRouteTableAssociation < Resource
+          type 'AWS::EC2::SubnetRouteTableAssociation'
           property :route_table, 'RouteTableId'
           property :subnet, 'SubnetId'
-
-          def initialize(*args)
-            super
-            type 'AWS::EC2::SubnetRouteTableAssociation'
-          end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def ec2_subnet_route_table_association(name, &block)
-        r = Model::Template::Resource::EC2SubnetRouteTableAssociation.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_ec2_vpc_gateway_attachment.rb
+++ b/lib/convection/model/template/resource/aws_ec2_vpc_gateway_attachment.rb
@@ -8,27 +8,11 @@ module Convection
         # AWS::EC2::VPCGatewayAttachment
         ##
         class EC2VPCGatewayAttachment < Resource
+          type 'AWS::EC2::VPCGatewayAttachment'
           property :vpc, 'VpcId'
           property :internet_gateway, 'InternetGatewayId'
           property :vpn_gateway, 'VpnGatewayId'
-
-          def initialize(*args)
-            super
-            type 'AWS::EC2::VPCGatewayAttachment'
-          end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def ec2_vpc_gateway_attachment(name, &block)
-        r = Model::Template::Resource::EC2VPCGatewayAttachment.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_elasticache_cluster.rb
+++ b/lib/convection/model/template/resource/aws_elasticache_cluster.rb
@@ -9,6 +9,7 @@ module Convection
         ##
         class ElastiCacheCluster < Resource
 
+          type 'AWS::ElastiCache::CacheCluster'
           property :auto_minor_version_upgrade, 'AutoMinorVersionUpgrade'
           property :cache_node_type, 'CacheNodeType'
           property :cache_security_group_names, 'CacheSecurityGroupNames'
@@ -17,25 +18,7 @@ module Convection
           property :engine, 'Engine'
           property :engine_version, 'EngineVersion'
           property :num_cache_nodes, 'NumCacheNodes'
-
-          def initialize(*args)
-            super
-            type 'AWS::ElastiCache::CacheCluster'
-          end
-
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def elasticache_cache_cluster(name, &block)
-        r = Model::Template::Resource::ElastiCacheCluster.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_elasticache_parameter_group.rb
+++ b/lib/convection/model/template/resource/aws_elasticache_parameter_group.rb
@@ -9,19 +9,10 @@ module Convection
         ##
         class ElastiCacheParameterGroup < Resource
 
-          type 'AWS::ElastiCache::ParameterGroup'
+          type 'AWS::ElastiCache::ParameterGroup', :elasticache_parameter_group
           property :cache_parameter_group_family, 'CacheParameterGroupFamily'
           property :description, 'Description'
-
-          def initialize(*args)
-            super
-            @properties['Properties'] = {}
-          end
-
-          def parameter(key, value)
-            @properties['Properties'][key] = value
-          end
-
+          property :parameter, 'Properties', :type => :hash
         end
       end
     end

--- a/lib/convection/model/template/resource/aws_elasticache_parameter_group.rb
+++ b/lib/convection/model/template/resource/aws_elasticache_parameter_group.rb
@@ -9,12 +9,12 @@ module Convection
         ##
         class ElastiCacheParameterGroup < Resource
 
+          type 'AWS::ElastiCache::ParameterGroup'
           property :cache_parameter_group_family, 'CacheParameterGroupFamily'
           property :description, 'Description'
 
           def initialize(*args)
             super
-            type 'AWS::ElastiCache::ParameterGroup'
             @properties['Properties'] = {}
           end
 
@@ -23,18 +23,6 @@ module Convection
           end
 
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def elasticache_parameter_group(name, &block)
-        r = Model::Template::Resource::ElastiCacheParameterGroup.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_elasticache_security_group.rb
+++ b/lib/convection/model/template/resource/aws_elasticache_security_group.rb
@@ -8,7 +8,7 @@ module Convection
         # AWS::ElastiCache::SecurityGroup
         ##
         class ElastiCacheSecurityGroup < Resource
-          type 'AWS::ElastiCache::SecurityGroup'
+          type 'AWS::ElastiCache::SecurityGroup', :elasticache_security_group
           property :description, 'Description'
         end
       end

--- a/lib/convection/model/template/resource/aws_elasticache_security_group.rb
+++ b/lib/convection/model/template/resource/aws_elasticache_security_group.rb
@@ -8,27 +8,9 @@ module Convection
         # AWS::ElastiCache::SecurityGroup
         ##
         class ElastiCacheSecurityGroup < Resource
-
+          type 'AWS::ElastiCache::SecurityGroup'
           property :description, 'Description'
-
-          def initialize(*args)
-            super
-            type 'AWS::ElastiCache::SecurityGroup'
-          end
-
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def elasticache_security_group(name, &block)
-        r = Model::Template::Resource::ElastiCacheSecurityGroup.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_elasticache_security_group_ingress.rb
+++ b/lib/convection/model/template/resource/aws_elasticache_security_group_ingress.rb
@@ -8,7 +8,7 @@ module Convection
         # AWS::ElastiCache::SecurityGroupIngress
         ##
         class ElastiCacheSecurityGroupIngress < Resource
-          type 'AWS::ElastiCache::SecurityGroupIngress'
+          type 'AWS::ElastiCache::SecurityGroupIngress', :elasticache_security_group_ingress
           property :cache_security_group_name, 'CacheSecurityGroupName'
           property :ec2_security_group_name, 'EC2SecurityGroupName'
           property :ec2_security_group_owner_id, 'EC2SecurityGroupOwnerId'

--- a/lib/convection/model/template/resource/aws_elasticache_security_group_ingress.rb
+++ b/lib/convection/model/template/resource/aws_elasticache_security_group_ingress.rb
@@ -8,29 +8,11 @@ module Convection
         # AWS::ElastiCache::SecurityGroupIngress
         ##
         class ElastiCacheSecurityGroupIngress < Resource
-
+          type 'AWS::ElastiCache::SecurityGroupIngress'
           property :cache_security_group_name, 'CacheSecurityGroupName'
           property :ec2_security_group_name, 'EC2SecurityGroupName'
           property :ec2_security_group_owner_id, 'EC2SecurityGroupOwnerId'
-
-          def initialize(*args)
-            super
-            type 'AWS::ElastiCache::SecurityGroupIngress'
-          end
-
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def elasticache_security_group_ingress(name, &block)
-        r = Model::Template::Resource::ElastiCacheSecurityGroupIngress.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_elb.rb
+++ b/lib/convection/model/template/resource/aws_elb.rb
@@ -10,22 +10,22 @@ module Convection
         class ELB < Resource
           include Model::Mixin::Taggable
 
-          type 'AWS::ElasticLoadBalancing::LoadBalancer'
+          type 'AWS::ElasticLoadBalancing::LoadBalancer', :elb
           property :access_logging_policy, 'AccessLoggingPolicy'
-          property :app_cookie_stickiness_policy, 'AppCookieStickinessPolicy', :array
-          property :lb_cookie_stickiness_policy, 'LBCookieStickinessPolicy', :array
-          property :availability_zone, 'AvailabilityZones', :array
+          property :app_cookie_stickiness_policy, 'AppCookieStickinessPolicy', :type => :list
+          property :lb_cookie_stickiness_policy, 'LBCookieStickinessPolicy', :type => :list
+          property :availability_zone, 'AvailabilityZones', :type => :list
           property :connection_draining_policy, 'ConnectionDrainingPolicy'
           property :connection_settings, 'ConnectionSettings'
           property :cross_zone, 'CrossZone'
           property :health_check, 'HealthCheck'
-          property :instance, 'Instances', :array
+          property :instance, 'Instances', :type => :list
           property :load_balancer_name, 'LoadBalancerName'
-          property :listener, 'Listeners', :array
-          property :policy, 'Policies', :array
+          property :listener, 'Listeners', :type => :list
+          property :policy, 'Policies', :type => :list
           property :scheme, 'Scheme'
-          property :security_group, 'SecurityGroups', :array
-          property :subnet, 'Subnets', :array
+          property :security_group, 'SecurityGroups', :type => :list
+          property :subnet, 'Subnets', :type => :list
 
           def render(*args)
             super.tap do |resource|

--- a/lib/convection/model/template/resource/aws_elb.rb
+++ b/lib/convection/model/template/resource/aws_elb.rb
@@ -1,18 +1,6 @@
 require_relative '../resource'
 
 module Convection
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def elb(name, &block)
-        r = Model::Template::Resource::ELB.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
-      end
-    end
-  end
-
   module Model
     class Template
       class Resource
@@ -22,12 +10,7 @@ module Convection
         class ELB < Resource
           include Model::Mixin::Taggable
 
-          def initialize(*args)
-            super
-
-            type 'AWS::ElasticLoadBalancing::LoadBalancer'
-          end
-
+          type 'AWS::ElasticLoadBalancing::LoadBalancer'
           property :access_logging_policy, 'AccessLoggingPolicy'
           property :app_cookie_stickiness_policy, 'AppCookieStickinessPolicy', :array
           property :lb_cookie_stickiness_policy, 'LBCookieStickinessPolicy', :array

--- a/lib/convection/model/template/resource/aws_iam_access_key.rb
+++ b/lib/convection/model/template/resource/aws_iam_access_key.rb
@@ -8,32 +8,12 @@ module Convection
         # AWS::IAM::AccessKey
         ##
         class IAMAccessKey < Resource
-          property :serial, 'Serial'
-          property :status, 'Status'
+          type 'AWS::IAM::AccessKey'
+          property :serial, 'Serial', :default => 0
+          property :status, 'Status', :default => 'Active'
           property :user_name, 'UserName'
-
-          def initialize(*args)
-            super
-            type 'AWS::IAM::AccessKey'
-
-            @properties['Serial'] = 0
-            @properties['Status'] = 'Active'
-          end
         end
       end
     end
   end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def iam_access_key(name, &block)
-        r = Model::Template::Resource::IAMAccessKey.new(name, self)
-        r.instance_exec(&block) if block
-
-        resources[name] = r
-      end
-    end
-  end
-
 end

--- a/lib/convection/model/template/resource/aws_iam_group.rb
+++ b/lib/convection/model/template/resource/aws_iam_group.rb
@@ -10,7 +10,7 @@ module Convection
         class IAMGroup < Resource
           type 'AWS::IAM::Group'
           property :path, 'Path'
-          property :policy, 'Policies', :array
+          property :policy, 'Policies', :type => :list
         end
       end
     end

--- a/lib/convection/model/template/resource/aws_iam_group.rb
+++ b/lib/convection/model/template/resource/aws_iam_group.rb
@@ -8,29 +8,11 @@ module Convection
         # AWS::IAM::Group
         ##
         class IAMGroup < Resource
+          type 'AWS::IAM::Group'
           property :path, 'Path'
           property :policy, 'Policies', :array
-
-          def initialize(*args)
-            super
-
-            type 'AWS::IAM::Group'
-          end
         end
       end
     end
   end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def iam_group(name, &block)
-        r = Model::Template::Resource::IAMGroup.new(name, self)
-        r.instance_exec(&block) if block
-
-        resources[name] = r
-      end
-    end
-  end
-
 end

--- a/lib/convection/model/template/resource/aws_iam_instance_profile.rb
+++ b/lib/convection/model/template/resource/aws_iam_instance_profile.rb
@@ -1,18 +1,6 @@
 require_relative '../resource'
 
 module Convection
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def iam_instance_profile(name, &block)
-        r = Model::Template::Resource::IAMInstanceProfile.new(name, self)
-        r.instance_exec(&block) if block
-
-        resources[name] = r
-      end
-    end
-  end
-
   module Model
     class Template
       class Resource
@@ -20,16 +8,12 @@ module Convection
         # AWS::IAM::IstanceProfile
         ##
         class IAMInstanceProfile < Resource
+          type 'AWS::IAM::InstanceProfile'
           property :path, 'Path'
 
           ## List of references to AWS::IAM::Roles.
           ## Currently, a maximum of one role can be assigned to an instance profile.
-          property :role, 'Roles', :array
-
-          def initialize(*args)
-            super
-            type 'AWS::IAM::InstanceProfile'
-          end
+          property :role, 'Roles', :type => :list
         end
       end
     end

--- a/lib/convection/model/template/resource/aws_iam_policy.rb
+++ b/lib/convection/model/template/resource/aws_iam_policy.rb
@@ -2,18 +2,6 @@ require 'forwardable'
 require_relative '../resource'
 
 module Convection
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def iam_policy(name, &block)
-        r = Model::Template::Resource::IAMPolicy.new(name, self)
-        r.instance_exec(&block) if block
-
-        resources[name] = r
-      end
-    end
-  end
-
   module Model
     class Template
       class Resource
@@ -23,14 +11,13 @@ module Convection
         class IAMPolicy < Resource
           extend Forwardable
 
+          type 'AWS::IAM::Policy'
           attr_reader :document
           def_delegators :@document, :allow, :id, :version, :statement
           def_delegator :@document, :name, :policy_name
 
           def initialize(*args)
             super
-
-            type 'AWS::IAM::Policy'
             @document = Model::Mixin::Policy.new(:template => @template)
 
             @properties['Groups'] = []

--- a/lib/convection/model/template/resource/aws_iam_policy.rb
+++ b/lib/convection/model/template/resource/aws_iam_policy.rb
@@ -12,6 +12,22 @@ module Convection
           extend Forwardable
 
           type 'AWS::IAM::Policy'
+          property :group, 'Groups', :type => :list,
+                                     :transform => proc { |resource|
+                                       depends_on(resource)
+                                       resource
+                                     }
+          property :role, 'Roles', :type => :list,
+                                   :transform => proc { |resource|
+                                     depends_on(resource)
+                                     resource
+                                   }
+          property :user, 'Users', :type => :list,
+                                   :transform => proc { |resource|
+                                     depends_on(resource)
+                                     resource
+                                   }
+
           attr_reader :document
           def_delegators :@document, :allow, :id, :version, :statement
           def_delegator :@document, :name, :policy_name
@@ -19,30 +35,12 @@ module Convection
           def initialize(*args)
             super
             @document = Model::Mixin::Policy.new(:template => @template)
-
-            @properties['Groups'] = []
-            @properties['Roles'] = []
-            @properties['Users'] = []
-          end
-
-          def group(resource)
-            depends_on(resource)
-            @properties['Groups'] << (resource.is_a?(Resource) ? resource.reference : resource)
-          end
-
-          def role(resource)
-            depends_on(resource)
-            @properties['Roles'] << (resource.is_a?(Resource) ? resource.reference : resource)
-          end
-
-          def user(resource)
-            depends_on(resource)
-            @properties['Users'] << (resource.is_a?(Resource) ? resource.reference : resource)
           end
 
           def render
-            document.render(@properties)
-            super
+            super.tap do |r|
+              document.render(r['Properties'])
+            end
           end
         end
       end

--- a/lib/convection/model/template/resource/aws_iam_role.rb
+++ b/lib/convection/model/template/resource/aws_iam_role.rb
@@ -2,15 +2,7 @@ require_relative '../resource'
 
 module Convection
   module DSL
-    ## Add DSL method to template namespace
     module Template
-      def iam_role(name, &block)
-        r = Model::Template::Resource::IAMRole.new(name, self)
-        r.instance_exec(&block) if block
-
-        resources[name] = r
-      end
-
       module Resource
         ## Role DSL
         module IAMRole
@@ -79,6 +71,7 @@ module Convection
         class IAMRole < Resource
           include DSL::Template::Resource::IAMRole
 
+          type 'AWS::IAM::Role'
           property :path, 'Path'
           attr_accessor :trust_relationship
           attr_reader :policies
@@ -88,8 +81,6 @@ module Convection
 
           def initialize(*args)
             super
-
-            type 'AWS::IAM::Role'
             @policies = []
           end
 

--- a/lib/convection/model/template/resource/aws_iam_role.rb
+++ b/lib/convection/model/template/resource/aws_iam_role.rb
@@ -10,7 +10,7 @@ module Convection
             add_policy = Model::Mixin::Policy.new(:name => policy_name, :template => @template)
             add_policy.instance_exec(&block) if block
 
-            @policies << add_policy
+            policies << add_policy
           end
 
           ## Create an IAM Instance Profile for this role
@@ -73,21 +73,15 @@ module Convection
 
           type 'AWS::IAM::Role'
           property :path, 'Path'
-          attr_accessor :trust_relationship
-          attr_reader :policies
+          property :policies, 'Policies', :type => :list
 
-          ## Reference to associated instance profile
+          attr_accessor :trust_relationship
           attr_reader :instance_profile
 
-          def initialize(*args)
-            super
-            @policies = []
-          end
-
           def render
-            @properties['Policies'] = @policies.map(&:render) unless @policies.empty?
-            @properties['AssumeRolePolicyDocument'] = trust_relationship.document unless trust_relationship.nil?
-            super
+            super.tap do |r|
+              r['Properties']['AssumeRolePolicyDocument'] = trust_relationship.document unless trust_relationship.nil?
+            end
           end
         end
       end

--- a/lib/convection/model/template/resource/aws_iam_user.rb
+++ b/lib/convection/model/template/resource/aws_iam_user.rb
@@ -2,15 +2,7 @@ require_relative '../resource'
 
 module Convection
   module DSL
-    ## Add DSL method to template namespace
     module Template
-      def iam_user(name, &block)
-        r = Model::Template::Resource::IAMUser.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
-      end
-
       module Resource
         ## Role DSL
         module IAMUser
@@ -49,6 +41,7 @@ module Convection
         class IAMUser < Resource
           include DSL::Template::Resource::IAMUser
 
+          type 'AWS::IAM::User'
           property :path, 'Path'
           property :login_profile, 'LoginProfile'
           property :group, 'Groups', :array
@@ -56,8 +49,6 @@ module Convection
 
           def initialize(*args)
             super
-
-            type 'AWS::IAM::User'
             @policies = []
           end
 

--- a/lib/convection/model/template/resource/aws_iam_user.rb
+++ b/lib/convection/model/template/resource/aws_iam_user.rb
@@ -10,7 +10,7 @@ module Convection
             add_policy = Model::Mixin::Policy.new(:name => policy_name, :template => @template)
             add_policy.instance_exec(&block) if block
 
-            @policies << add_policy
+            policies << add_policy
           end
 
           def with_key(serial = 0, &block)
@@ -44,18 +44,8 @@ module Convection
           type 'AWS::IAM::User'
           property :path, 'Path'
           property :login_profile, 'LoginProfile'
-          property :group, 'Groups', :array
-          attr_reader :policies
-
-          def initialize(*args)
-            super
-            @policies = []
-          end
-
-          def render
-            @properties['Policies'] = @policies.map(&:render) unless @policies.empty?
-            super
-          end
+          property :group, 'Groups', :type => :list
+          property :policies, 'Policies', :type => :list
         end
       end
     end

--- a/lib/convection/model/template/resource/aws_rds_db_instance.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_instance.rb
@@ -10,7 +10,7 @@ module Convection
         class RDSDBInstance < Resource
           include Model::Mixin::Taggable
 
-          type 'AWS::RDS::DBInstance'
+          type 'AWS::RDS::DBInstance', :rds_instance
           property :identifier, 'DBInstanceIdentifier'
           property :instance_class, 'DBInstanceClass'
           property :engine, 'Engine'
@@ -40,8 +40,8 @@ module Convection
           property :multi_az, 'MultiAZ'
           property :publicly_accessible, 'PubliclyAccessible'
           property :subnet_group, 'DBSubnetGroupName'
-          property :security_group, 'DBSecurityGroups', :array
-          property :vpc_security_group, 'VPCSecurityGroups', :array
+          property :security_group, 'DBSecurityGroups', :type => :list
+          property :vpc_security_group, 'VPCSecurityGroups', :type => :list
 
           def render(*args)
             super.tap do |resource|

--- a/lib/convection/model/template/resource/aws_rds_db_instance.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_instance.rb
@@ -10,6 +10,7 @@ module Convection
         class RDSDBInstance < Resource
           include Model::Mixin::Taggable
 
+          type 'AWS::RDS::DBInstance'
           property :identifier, 'DBInstanceIdentifier'
           property :instance_class, 'DBInstanceClass'
           property :engine, 'Engine'
@@ -42,29 +43,12 @@ module Convection
           property :security_group, 'DBSecurityGroups', :array
           property :vpc_security_group, 'VPCSecurityGroups', :array
 
-          def initialize(*args)
-            super
-            type 'AWS::RDS::DBInstance'
-          end
-
           def render(*args)
             super.tap do |resource|
               render_tags(resource)
             end
           end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def rds_instance(name, &block)
-        r = Model::Template::Resource::RDSDBInstance.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_rds_db_parameter_group.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_parameter_group.rb
@@ -10,18 +10,10 @@ module Convection
         class RDSDBParameterGroup < Resource
           include Model::Mixin::Taggable
 
-          type 'AWS::RDS::DBParameterGroup'
+          type 'AWS::RDS::DBParameterGroup', :rds_parameter_group
           property :description, 'Description'
           property :family, 'Family'
-
-          def initialize(*args)
-            super
-            @properties['Parameters'] = {}
-          end
-
-          def parameter(key, value)
-            @properties['Parameters'][key] = value
-          end
+          property :parameter, 'Parameters', :type => :hash
 
           def render(*args)
             super.tap do |resource|

--- a/lib/convection/model/template/resource/aws_rds_db_parameter_group.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_parameter_group.rb
@@ -10,12 +10,12 @@ module Convection
         class RDSDBParameterGroup < Resource
           include Model::Mixin::Taggable
 
+          type 'AWS::RDS::DBParameterGroup'
           property :description, 'Description'
           property :family, 'Family'
 
           def initialize(*args)
             super
-            type 'AWS::RDS::DBParameterGroup'
             @properties['Parameters'] = {}
           end
 
@@ -29,18 +29,6 @@ module Convection
             end
           end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def rds_parameter_group(name, &block)
-        r = Model::Template::Resource::RDSDBParameterGroup.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_rds_db_security_group.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_security_group.rb
@@ -10,14 +10,10 @@ module Convection
         class RDSDBSecurityGroup < Resource
           include Model::Mixin::Taggable
 
-          type 'AWS::RDS::DBSecurityGroup'
+          type 'AWS::RDS::DBSecurityGroup', :rds_security_group
           property :description, 'GroupDescription'
           property :vpc, 'EC2VpcId'
-
-          def initialize(*args)
-            super
-            @properties['DBSecurityGroupIngress'] = []
-          end
+          property :ingress, 'DBSecurityGroupIngress', :type => :list
 
           def security_group_ingress(&block)
             # A new code block defines a new ingress group

--- a/lib/convection/model/template/resource/aws_rds_db_security_group.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_security_group.rb
@@ -10,12 +10,12 @@ module Convection
         class RDSDBSecurityGroup < Resource
           include Model::Mixin::Taggable
 
+          type 'AWS::RDS::DBSecurityGroup'
           property :description, 'GroupDescription'
           property :vpc, 'EC2VpcId'
 
           def initialize(*args)
             super
-            type 'AWS::RDS::DBSecurityGroup'
             @properties['DBSecurityGroupIngress'] = []
           end
 
@@ -27,12 +27,15 @@ module Convection
 
           def ec2_security_group(group, owner)
             @properties['DBSecurityGroupIngress'].last.merge!(
-              { 'EC2SecurityGroupName': group, 'EC2SecurityGroupOwnerId': owner }
+              :EC2SecurityGroupName => group,
+              :EC2SecurityGroupOwnerId => owner
             )
           end
 
           def cidr_ip(cidr_block)
-            @properties['DBSecurityGroupIngress'].last.merge!({ 'CIDRIP': cidr_block })
+            @properties['DBSecurityGroupIngress'].last.merge!(
+              :CIDRIP => cidr_block
+            )
           end
 
           def render(*args)
@@ -42,19 +45,6 @@ module Convection
           end
         end
       end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def rds_security_group(name, &block)
-        r = Model::Template::Resource::RDSDBSecurityGroup.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
-      end
-
     end
   end
 end

--- a/lib/convection/model/template/resource/aws_rds_db_subnet_group.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_subnet_group.rb
@@ -10,7 +10,7 @@ module Convection
         class RDSDBSubnetGroup < Resource
           include Model::Mixin::Taggable
 
-          type 'AWS::RDS::DBSubnetGroup'
+          type 'AWS::RDS::DBSubnetGroup', :rds_subnet_group
           property :subnet, 'SubnetIds', :type => :list
           property :description, 'DBSubnetGroupDescription'
 

--- a/lib/convection/model/template/resource/aws_rds_db_subnet_group.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_subnet_group.rb
@@ -10,14 +10,9 @@ module Convection
         class RDSDBSubnetGroup < Resource
           include Model::Mixin::Taggable
 
-          property :subnet, 'SubnetIds', :array
+          type 'AWS::RDS::DBSubnetGroup'
+          property :subnet, 'SubnetIds', :type => :list
           property :description, 'DBSubnetGroupDescription'
-
-          def initialize(*args)
-            super
-            type 'AWS::RDS::DBSubnetGroup'
-            @properties['SubnetIds'] = []
-          end
 
           def render(*args)
             super.tap do |resource|
@@ -25,18 +20,6 @@ module Convection
             end
           end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def rds_subnet_group(name, &block)
-        r = Model::Template::Resource::RDSDBSubnetGroup.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_route53_health_check.rb
+++ b/lib/convection/model/template/resource/aws_route53_health_check.rb
@@ -8,26 +8,9 @@ module Convection
         # AWS::Route53::HealthCheck
         ##
         class Route53HealthCheck < Resource
-
+          type 'AWS::Route53::HealthCheck'
           property :health_check_config, 'HealthCheckConfig'
-
-          def initialize(*args)
-            super
-            type 'AWS::Route53::HealthCheck'
-          end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def route53_health_check(name, &block)
-        r = Model::Template::Resource::Route53HealthCheck.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_route53_health_check.rb
+++ b/lib/convection/model/template/resource/aws_route53_health_check.rb
@@ -8,7 +8,7 @@ module Convection
         # AWS::Route53::HealthCheck
         ##
         class Route53HealthCheck < Resource
-          type 'AWS::Route53::HealthCheck'
+          type 'AWS::Route53::HealthCheck', :route53_healthcheck
           property :health_check_config, 'HealthCheckConfig'
         end
       end

--- a/lib/convection/model/template/resource/aws_route53_recordset.rb
+++ b/lib/convection/model/template/resource/aws_route53_recordset.rb
@@ -8,6 +8,7 @@ module Convection
         # AWS::EC2::Instance
         ##
         class Route53RecordSet < Resource
+          type 'AWS::Route53::RecordSet'
           property :alias_target, 'AliasTarget'
           property :comment, 'Comment'
           property :failover, 'Failover'
@@ -22,24 +23,7 @@ module Convection
           property :ttl, 'TTL'
           property :record_type, 'Type'
           property :weight, 'Weight'
-
-          def initialize(*args)
-            super
-            type 'AWS::Route53::RecordSet'
-          end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def route53_recordset(name, &block)
-        r = Model::Template::Resource::Route53RecordSet.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_route53_recordset.rb
+++ b/lib/convection/model/template/resource/aws_route53_recordset.rb
@@ -8,7 +8,7 @@ module Convection
         # AWS::EC2::Instance
         ##
         class Route53RecordSet < Resource
-          type 'AWS::Route53::RecordSet'
+          type 'AWS::Route53::RecordSet', :route53_recordset
           property :alias_target, 'AliasTarget'
           property :comment, 'Comment'
           property :failover, 'Failover'

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -10,6 +10,7 @@ module Convection
         class S3Bucket < Resource
           include Model::Mixin::Taggable
 
+          type 'AWS::S3::Bucket'
           property :bucket_name, 'BucketName'
           property :access_control, 'AccessControl'
           property :cors_configurationm, 'CorsConfiguration'
@@ -18,29 +19,12 @@ module Convection
           property :notification_configuration, 'NotificationConfiguration'
           property :version_configuration, 'VersionConfiguration'
 
-          def initialize(*args)
-            super
-            type 'AWS::S3::Bucket'
-          end
-
           def render(*args)
             super.tap do |resource|
               render_tags(resource)
             end
           end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def s3_bucket(name, &block)
-        r = Model::Template::Resource::S3Bucket.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_s3_bucket_policy.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket_policy.rb
@@ -2,18 +2,6 @@ require 'forwardable'
 require_relative '../resource'
 
 module Convection
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def s3_bucket_policy(name, &block)
-        r = Model::Template::Resource::S3BucketPolicy.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
-      end
-    end
-  end
-
   module Model
     class Template
       class Resource
@@ -23,6 +11,7 @@ module Convection
         class S3BucketPolicy < Resource
           extend Forwardable
 
+          type 'AWS::S3::BucketPolicy'
           property :bucket, 'Bucket'
           attr_reader :document #, 'PolicyDocument'
 
@@ -31,7 +20,6 @@ module Convection
 
           def initialize(*args)
             super
-            type 'AWS::S3::BucketPolicy'
             @document = Model::Mixin::Policy.new(:name => false, :template => @template)
           end
 

--- a/lib/convection/model/template/resource/aws_s3_bucket_policy.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket_policy.rb
@@ -24,8 +24,9 @@ module Convection
           end
 
           def render
-            document.render(@properties)
-            super
+            super.tap do |r|
+              document.render(r['Properties'])
+            end
           end
         end
       end

--- a/lib/convection/model/template/resource/aws_sns_topic.rb
+++ b/lib/convection/model/template/resource/aws_sns_topic.rb
@@ -10,7 +10,7 @@ module Convection
         class SNSTopic < Resource
           type 'AWS::SNS::Topic'
           property :display_name, 'DisplayName'
-          property :subscription, 'Subscription', :array
+          property :subscription, 'Subscription', :type => :list
           property :topic_name, 'TopicName'
         end
       end

--- a/lib/convection/model/template/resource/aws_sns_topic.rb
+++ b/lib/convection/model/template/resource/aws_sns_topic.rb
@@ -8,27 +8,11 @@ module Convection
         # AWS::SNS::Topic
         ##
         class SNSTopic < Resource
+          type 'AWS::SNS::Topic'
           property :display_name, 'DisplayName'
           property :subscription, 'Subscription', :array
           property :topic_name, 'TopicName'
-
-          def initialize(*args)
-            super
-            type 'AWS::SNS::Topic'
-          end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def sns_topic(name, &block)
-        r = Model::Template::Resource::SNSTopic.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_sqs_queue.rb
+++ b/lib/convection/model/template/resource/aws_sqs_queue.rb
@@ -10,6 +10,7 @@ module Convection
         class SQSQueue < Resource
           include Model::Mixin::Taggable
 
+          type 'AWS::SQS::Queue'
           property :delay_seconds, 'DelaySeconds'
           property :maximum_message_size, 'MaximumMessageSize'
           property :message_retention_period, 'MessageRetentionPeriod'
@@ -18,29 +19,12 @@ module Convection
           property :redrive_policy, 'RedrivePolicy'
           property :visibility_timeout, 'VisibilityTimeout'
 
-          def initialize(*args)
-            super
-            type 'AWS::SQS::Queue'
-          end
-
           def render(*args)
             super.tap do |resource|
               render_tags(resource)
             end
           end
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def sqs_queue(name, &block)
-        r = Model::Template::Resource::SQSQueue.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_sqs_queue_policy.rb
+++ b/lib/convection/model/template/resource/aws_sqs_queue_policy.rb
@@ -8,32 +8,10 @@ module Convection
         # AWS::SQS::QueuePolicy
         ##
         class SQSQueuePolicy < Resource
+          type 'AWS::SQS::QueuePolicy'
+          property :queue, 'Queues', :type => :list
           property :policy_document, 'PolicyDocument'
-
-          def initialize(*args)
-            super
-
-            type 'AWS::SQS::QueuePolicy'
-            @properties['Queues'] = []
-          end
-
-          def queue(value)
-            @properties['Queues'] << value
-          end
-          
         end
-      end
-    end
-  end
-
-  module DSL
-    ## Add DSL method to template namespace
-    module Template
-      def sqs_queue_policy(name, &block)
-        r = Model::Template::Resource::SQSQueuePolicy.new(name, self)
-
-        r.instance_exec(&block) if block
-        resources[name] = r
       end
     end
   end


### PR DESCRIPTION
* Big factor down of noisy DSL boilerplate in resources
* Improved namespace management. resource DSL is now available within other resources (e.g. define ec2_instances inside of a VPC resource's closure)
* Add per-resource-property state tracking. Load resources and templates from the CF API at startup and populate a 'current_state' value in each PropertyInstance.