### PR TITLE
Diff new stack

### DIFF
--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -44,7 +44,6 @@ module Convection
       def diff(&block)
         @cloudfile.deck.each do |stack|
           block.call(Model::Event.new(:compare, "Compare local state of stack #{ stack.name } (#{ stack.cloud_name }) with remote template", :info))
-          next block.call(Model::Event.new(:create, "Stack #{ stack.cloud_name } is not yet defined", :info)) unless stack.exist?
 
           difference = stack.diff
           next block.call(Model::Event.new(:unchanged, "Stack #{ stack.cloud_name } Has no changes", :info)) if difference.empty?


### PR DESCRIPTION
This allows us to diff a new stack that hasn't yet been converged.  This
is useful to do a last verification before converging.