### PR TITLE
Add an RDS option to allow encryption.

### DIFF
--- a/lib/convection/model/template/resource/aws_rds_db_instance.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_instance.rb
@@ -30,6 +30,7 @@ module Convection
           property :option_group, 'OptionGroupName'
 
           property :storage_encrypted, 'StorageEncrypted'
+          property :kms_key_id, 'KmsKeyId'
           property :allocated_storage, 'AllocatedStorage'
           property :allow_major_version_upgrade, 'AllowMajorVersionUpgrade'
           property :auto_minor_version_upgrade, 'AutoMinorVersionUpgrade'

--- a/lib/convection/model/template/resource/aws_rds_db_instance.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_instance.rb
@@ -29,6 +29,7 @@ module Convection
           property :parameter_group, 'DBParameterGroupName'
           property :option_group, 'OptionGroupName'
 
+          property :storage_encrypted, 'StorageEncrypted'
           property :allocated_storage, 'AllocatedStorage'
           property :allow_major_version_upgrade, 'AllowMajorVersionUpgrade'
           property :auto_minor_version_upgrade, 'AutoMinorVersionUpgrade'


### PR DESCRIPTION
For Nexpose, we want our RDS instances to have encryption enabled.

I created a PR on top of hamer-time. Seems razor-convection is dependent on this branch from github.