### PR TITLE
Add support for encryption at rest for RDS.

### DIFF
--- a/lib/convection/model/template/resource/aws_rds_db_instance.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_instance.rb
@@ -17,6 +17,7 @@ module Convection
           property :engine_version, 'EngineVersion'
           property :license_model, 'LicenseModel'
           property :storage_type, 'StorageType'
+          property :storage_encrypted, 'StorageEncrypted'
           property :iops, 'Iops'
           property :port, 'Port'
           property :master, 'SourceDBInstanceIdentifier'


### PR DESCRIPTION
This adds support for encryption at rest for RDS instance types which support the feature.

On a related note, AWS::EC2::Volume needs to be created to be able to support this globally for all EC2 instances which support disk encryption.

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volume.html