### PR TITLE
Only build master and master-based pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+    - master
 language: ruby
 rvm:
   - 2.0.0


### PR DESCRIPTION
cc @bturner-r7 @athompson-r7 @eciramella-r7 

---

Thoughts? This *should* fix the weird behaviour of building feature branches twice. We can add other branches to the `branches.only` array which accepts strings/regex. We could add a new line `- /^(release|staging)\/.*$/` in the YAML for example to build PRs/commits to branches named using the staging/release convention.