### PR TITLE
Allow SQS policy to be defined like S3 policies.

### DIFF
--- a/lib/convection/model/template/resource/aws_sqs_queue_policy.rb
+++ b/lib/convection/model/template/resource/aws_sqs_queue_policy.rb
@@ -12,7 +12,7 @@ module Convection
           extend Forwardable
 
           type 'AWS::SQS::QueuePolicy'
-          property :queues, 'Queues'
+          property :queue, 'Queues', :type => :list
           attr_reader :document
 
           def_delegators :@document, :allow, :id, :version, :statement

--- a/lib/convection/model/template/resource/aws_sqs_queue_policy.rb
+++ b/lib/convection/model/template/resource/aws_sqs_queue_policy.rb
@@ -1,3 +1,4 @@
+require 'forwardable'
 require_relative '../resource'
 
 module Convection
@@ -8,9 +9,25 @@ module Convection
         # AWS::SQS::QueuePolicy
         ##
         class SQSQueuePolicy < Resource
+          extend Forwardable
+
           type 'AWS::SQS::QueuePolicy'
-          property :queue, 'Queues', :type => :list
-          property :policy_document, 'PolicyDocument'
+          property :queues, 'Queues'
+          attr_reader :document
+
+          def_delegators :@document, :allow, :id, :version, :statement
+          def_delegator :@document, :name, :policy_name
+
+          def initialize(*args)
+            super
+            @document = Model::Mixin::Policy.new(:name => false, :template => @template)
+          end
+
+          def render
+            super.tap do |r|
+              document.render(r['Properties'])
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
SQS policies are similar to S3 and SNS. No reason for SQS policies to deviate from SQS and S3