### PR TITLE
Add CloudFront Support

### DIFF
--- a/lib/convection/model/template/resource.rb
+++ b/lib/convection/model/template/resource.rb
@@ -268,6 +268,7 @@ module Convection
           alias_method :push, :set
 
           def render
+            return default if value.nil? || value.empty?
             value.map do |val|
               next val.reference if val.is_a?(Resource)
               val.respond_to?(:render) ? val.render : val

--- a/lib/convection/model/template/resource/aws_cloudfront_distribution.rb
+++ b/lib/convection/model/template/resource/aws_cloudfront_distribution.rb
@@ -14,27 +14,28 @@ module Convection
         #
         # cloudfront_distribution 'MySiteWebsite' do
         #   config do
-        #   cname 'mysite.example.com'
-        #   default_root_object 'index.html'
-        #   price_class 'PriceClass_100'
-        #   default_cache_behavior do
-        #     forwarded_values do
-        #       query_string false
+        #     cname 'mysite.example.com'
+        #     default_root_object 'index.html'
+        #     price_class 'PriceClass_100'
+        #     default_cache_behavior do
+        #       forwarded_values do
+        #         query_string false
+        #       end
+        #       target_origin 's3-mysite-bucket'
+        #       viewer_protocol_policy 'redirect-to-https'
         #     end
-        #     target_origin 's3-mysite-bucket'
-        #     viewer_protocol_policy 'redirect-to-https'
-        #   end
-        #   origin do
-        #     id 's3-mysite-bucket'
-        #     domain_name "mysite.example.com.s3-website-#{stack.region}.amazonaws.com"
-        #     custom_origin do
-        #       protocol_policy 'http-only'
+        #     origin do
+        #       id 's3-mysite-bucket'
+        #       domain_name "mysite.example.com.s3-website-#{stack.region}.amazonaws.com"
+        #       custom_origin do
+        #         protocol_policy 'http-only'
+        #       end
         #     end
-        #   end
-        #   viewer_certificate do
-        #     iam_certificate 'EXAMPLECERTID'
-        #     minimum_protocol_version 'TLSv1'
-        #     ssl_support_method 'sni-only'
+        #     viewer_certificate do
+        #       iam_certificate 'EXAMPLECERTID'
+        #       minimum_protocol_version 'TLSv1'
+        #       ssl_support_method 'sni-only'
+        #     end
         #   end
         # end
         #

--- a/lib/convection/model/template/resource/aws_cloudfront_distribution.rb
+++ b/lib/convection/model/template/resource/aws_cloudfront_distribution.rb
@@ -6,7 +6,38 @@ module Convection
       class Resource
         ##
         # AWS::CloudFront::Distribution
-        ##
+        #
+        # Creates an Amazon CloudFront web distribution.   See
+        # {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution.html AWS::CloudFront::Distribution}.
+        #
+        # == Example
+        #
+        # cloudfront_distribution 'MySiteWebsite' do
+        #   config do
+        #   cname 'mysite.example.com'
+        #   default_root_object 'index.html'
+        #   price_class 'PriceClass_100'
+        #   default_cache_behavior do
+        #     forwarded_values do
+        #       query_string false
+        #     end
+        #     target_origin 's3-mysite-bucket'
+        #     viewer_protocol_policy 'redirect-to-https'
+        #   end
+        #   origin do
+        #     id 's3-mysite-bucket'
+        #     domain_name "mysite.example.com.s3-website-#{stack.region}.amazonaws.com"
+        #     custom_origin do
+        #       protocol_policy 'http-only'
+        #     end
+        #   end
+        #   viewer_certificate do
+        #     iam_certificate 'EXAMPLECERTID'
+        #     minimum_protocol_version 'TLSv1'
+        #     ssl_support_method 'sni-only'
+        #   end
+        # end
+        #
         class CloudFrontDistribution < Resource
           include Model::Mixin::Taggable
 

--- a/lib/convection/model/template/resource/aws_cloudfront_distribution.rb
+++ b/lib/convection/model/template/resource/aws_cloudfront_distribution.rb
@@ -1,0 +1,32 @@
+require_relative '../resource'
+
+module Convection
+  module Model
+    class Template
+      class Resource
+        ##
+        # AWS::CloudFront::Distribution
+        ##
+        class CloudFrontDistribution < Resource
+          include Model::Mixin::Taggable
+
+          type 'AWS::CloudFront::Distribution', :cloudfront_distribution
+          property :config, 'DistributionConfig'
+
+          # Append a network interface to network_interfaces
+          def config(&block)
+            config = ResourceProperty::CloudFrontDistributionConfig.new(self)
+            config.instance_exec(&block) if block
+            properties['DistributionConfig'].set(config)
+          end
+
+          def render(*args)
+            super.tap do |resource|
+              render_tags(resource)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_cloudfront_cachebehavior.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_cachebehavior.rb
@@ -1,0 +1,29 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents a {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-cachebehavior.html
+        # CloudFront DistributionConfig CacheBehavior Embedded Property Type}
+        class CloudFrontCacheBehavior < ResourceProperty
+          property :allowed_methods, 'AllowedMethods', :type => :list, :default => %w(HEAD GET)
+          property :cached_methods, 'CachedMethods', :type => :list
+          property :forwarded_values, 'ForwardedValues'
+          property :min_ttl, 'MinTTL'
+          property :path_pattern, 'PathPattern', :default => '*'
+          property :smooth_streaming, 'SmoothStreaming'
+          property :target_origin, 'TargetOriginId'
+          property :trusted_signer, 'TrustedSigners', :type => :list
+          property :viewer_protocol_policy, 'ViewerProtocolPolicy', :default => 'allow-all'
+
+          def forwarded_values(&block)
+            values = ResourceProperty::CloudFrontForwardedValues.new(self)
+            values.instance_exec(&block) if block
+            properties['ForwardedValues'].set(values)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_cloudfront_customerrorresponse.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_customerrorresponse.rb
@@ -1,0 +1,18 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents a {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig-customerrorresponse.html
+        # CloudFront DistributionConfig Restrictions GeoRestriction Embedded Property Type}
+        class CloudFrontCustomErrorResponse < ResourceProperty
+          property :min_ttl, 'ErrorCachingMinTTL'
+          property :error_code, 'ErrorCode'
+          property :response_code, 'ResponseCode'
+          property :response_page_path, 'ResponsePagePath'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_cloudfront_customorigin.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_customorigin.rb
@@ -1,0 +1,17 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents a {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-customorigin.html
+        # CloudFront DistributionConfig Origin S3Origin Embedded Property Type}
+        class CloudFrontCustomOrigin < ResourceProperty
+          property :http_port, 'HTTPPort', :default => 80
+          property :https_port, 'HTTPSPort', :default => 443
+          property :protocol_policy, 'OriginProtocolPolicy'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_cloudfront_defaultcachebehavior.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_defaultcachebehavior.rb
@@ -1,0 +1,28 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents a {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-defaultcachebehavior.html
+        # CloudFront DefaultCacheBehavior Embedded Property Type}
+        class CloudFrontDefaultCacheBehavior < ResourceProperty
+          property :allowed_methods, 'AllowedMethods', :type => :list, :default => %w(HEAD GET)
+          property :cached_methods, 'CachedMethods', :type => :list
+          property :forwarded_values, 'ForwardedValues'
+          property :min_ttl, 'MinTTL'
+          property :smooth_streaming, 'SmoothStreaming'
+          property :target_origin, 'TargetOriginId'
+          property :trusted_signer, 'TrustedSigners', :type => :list
+          property :viewer_protocol_policy, 'ViewerProtocolPolicy', :default => 'allow-all'
+
+          def forwarded_values(&block)
+            values = ResourceProperty::CloudFrontForwardedValues.new(self)
+            values.instance_exec(&block) if block
+            properties['ForwardedValues'].set(values)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_cloudfront_distribution_config.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_distribution_config.rb
@@ -45,7 +45,6 @@ module Convection
             properties['Logging'].set(logging)
           end
 
-
           def origin(&block)
             origin = ResourceProperty::CloudFrontOrigin.new(self)
             origin.instance_exec(&block) if block

--- a/lib/convection/model/template/resource_property/aws_cloudfront_distribution_config.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_distribution_config.rb
@@ -1,0 +1,49 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents a {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig.html
+        # CloudFront DistributionConfig Embedded Property Type}
+        class CloudFrontDistributionConfig < ResourceProperty
+          # NOTE: we avoid overloading Ruby's alias here by using cname
+          property :cname, 'Aliases', :type => :list
+          property :cache_behaviors, 'CacheBehaviors', :type => :list
+          property :comment, 'Comment'
+          property :default_cache_behavior, 'DefaultCacheBehavior'
+          property :default_root_object, 'DefaultRootObject'
+          property :enabled, 'Enabled', :default => true
+          property :origins, 'Origins', :type => :list
+          property :price_class, 'PriceClass'
+          property :viewer_certificate, 'ViewerCertificate'
+
+          # Append a network interface to network_interfaces
+          def cache_behavior(&block)
+            behavior = ResourceProperty::CloudFrontCacheBehavior.new(self)
+            behavior.instance_exec(&block) if block
+            cache_behaviors << behavior
+          end
+
+          def default_cache_behavior(&block)
+            behavior = ResourceProperty::CloudFrontDefaultCacheBehavior.new(self)
+            behavior.instance_exec(&block) if block
+            properties['DefaultCacheBehavior'].set(behavior)
+          end
+
+          def origin(&block)
+            origin = ResourceProperty::CloudFrontOrigin.new(self)
+            origin.instance_exec(&block) if block
+            origins << origin
+          end
+
+          def viewer_certificate(&block)
+            cert = ResourceProperty::CloudFrontViewerCertificate.new(self)
+            cert.instance_exec(&block) if block
+            properties['ViewerCertificate'].set(cert)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_cloudfront_distribution_config.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_distribution_config.rb
@@ -11,18 +11,26 @@ module Convection
           property :cname, 'Aliases', :type => :list
           property :cache_behaviors, 'CacheBehaviors', :type => :list
           property :comment, 'Comment'
+          property :custom_error_responses, 'CustomErrorResponses', :type => :array
           property :default_cache_behavior, 'DefaultCacheBehavior'
           property :default_root_object, 'DefaultRootObject'
           property :enabled, 'Enabled', :default => true
+          property :logging, 'Logging'
           property :origins, 'Origins', :type => :list
           property :price_class, 'PriceClass'
+          property :restrictions, 'Restrictions'
           property :viewer_certificate, 'ViewerCertificate'
 
-          # Append a network interface to network_interfaces
           def cache_behavior(&block)
             behavior = ResourceProperty::CloudFrontCacheBehavior.new(self)
             behavior.instance_exec(&block) if block
             cache_behaviors << behavior
+          end
+
+          def custom_error_response(&block)
+            response = ResourceProperty::CloudFrontCustomErrorResponse.new(self)
+            response.instance_exec(&block) if block
+            custom_error_responses << response
           end
 
           def default_cache_behavior(&block)
@@ -31,10 +39,23 @@ module Convection
             properties['DefaultCacheBehavior'].set(behavior)
           end
 
+          def logging(&block)
+            logging = ResourceProperty::CloudFrontLogging.new(self)
+            logging.instance_exec(&block) if block
+            properties['Logging'].set(logging)
+          end
+
+
           def origin(&block)
             origin = ResourceProperty::CloudFrontOrigin.new(self)
             origin.instance_exec(&block) if block
             origins << origin
+          end
+
+          def restrictions(&block)
+            restrictions = ResourceProperty::CloudFrontRestrictions.new(self)
+            restrictions.instance_exec(&block) if block
+            properties['Restrictions'].set(restrictions)
           end
 
           def viewer_certificate(&block)

--- a/lib/convection/model/template/resource_property/aws_cloudfront_forwardedvalues.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_forwardedvalues.rb
@@ -1,0 +1,16 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents a {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-forwardedvalues.html
+        # CloudFront ForwardedValues Embedded Property Type}
+        class CloudFrontForwardedValues < ResourceProperty
+          property :headers, 'Headers', :type => :list
+          property :query_string, 'QueryString', :default => false
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_cloudfront_georestriction.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_georestriction.rb
@@ -1,0 +1,16 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents a {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig-restrictions-georestriction.html
+        # CloudFront DistributionConfig Restrictions GeoRestriction Embedded Property Type}
+        class CloudFrontGeoRestriction < ResourceProperty
+          property :locations, 'Locations', :type => :array
+          property :type, 'RestrictionType'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_cloudfront_logging.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_logging.rb
@@ -1,0 +1,17 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents a {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-logging.html
+        # CloudFront Logging Embedded Property Type}
+        class CloudFrontLogging < ResourceProperty
+          property :bucket, 'Bucket'
+          property :include_cookies, 'IncludeCookies'
+          property :prefix, 'Prefix'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_cloudfront_origin.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_origin.rb
@@ -1,0 +1,24 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents a {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-origin.html
+        # CloudFront Origin Embedded Property Type}
+        class CloudFrontOrigin < ResourceProperty
+          property :domain_name, 'DomainName'
+          property :id, 'Id'
+          property :origin_path, 'OriginPath'
+          property :s3_origin, 'S3OriginConfig'
+
+          def s3_origin(&block)
+            origin = ResourceProperty::CloudFrontS3Origin.new(self)
+            origin.instance_exec(&block) if block
+            properties['S3OriginConfig'].set(origin)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_cloudfront_origin.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_origin.rb
@@ -7,10 +7,17 @@ module Convection
         # Represents a {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-origin.html
         # CloudFront Origin Embedded Property Type}
         class CloudFrontOrigin < ResourceProperty
+          property :custom_origin, 'CustomOriginConfig'
           property :domain_name, 'DomainName'
           property :id, 'Id'
           property :origin_path, 'OriginPath'
           property :s3_origin, 'S3OriginConfig'
+
+          def custom_origin(&block)
+            origin = ResourceProperty::CloudFrontCustomOrigin.new(self)
+            origin.instance_exec(&block) if block
+            properties['CustomOriginConfig'].set(origin)
+          end
 
           def s3_origin(&block)
             origin = ResourceProperty::CloudFrontS3Origin.new(self)

--- a/lib/convection/model/template/resource_property/aws_cloudfront_restrictions.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_restrictions.rb
@@ -1,0 +1,21 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents a {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig-restrictions.html
+        # CloudFront DistributionConfiguration Restrictions Embedded Property Type}
+        class CloudFrontRestrictions < ResourceProperty
+          property :geo, 'GeoRestriction'
+
+          def geo(&block)
+            restriction = ResourceProperty::CloudFrontGeoRestriction.new(self)
+            restriction.instance_exec(&block) if block
+            properties['GeoRestriction'].set(restriction)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_cloudfront_s3origin.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_s3origin.rb
@@ -1,0 +1,15 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents a {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-s3origin.html
+        # CloudFront DistributionConfig Origin S3Origin Embedded Property Type}
+        class CloudFrontS3Origin < ResourceProperty
+          property :access_identity, 'OriginAccessIdentity'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_cloudfront_viewercertificate.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_viewercertificate.rb
@@ -1,0 +1,18 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents a {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distributionconfig-viewercertificate.html
+        # CloudFront DistributionConfiguration ViewerCertificate Embedded Property Type}
+        class CloudFrontViewerCertificate < ResourceProperty
+          property :use_default, 'CloudFrontDefaultCertificate'
+          property :iam_certificate, 'IamCertificateId'
+          property :minimum_protocol_version, 'MinimumProtocolVersion'
+          property :ssl_support_method, 'SslSupportMethod'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the `AWS::CloudFront::Distribution` type and sub-types.

This allows specifying CloudFront configuration similar to:

 ```ruby
cloudfront_distribution 'FooDistro' do
  config do
    cname 'stuff.example.com'
    default_root_object 'index.html'
    price_class 'PriceClass_100'
    default_cache_behavior do
      forwarded_values do
        query_string false
      end
      target_origin 's3-stuff-example-com'
      viewer_protocol_policy 'redirect-to-https'
    end
    origin do
      id 's3-stuff-example-com'
      domain_name "stuff.example.com.s3-website-#{stack.region}.amazonaws.com"
      custom_origin do
        protocol_policy 'http-only'
      end
    end
    viewer_certificate do
      iam_certificate 'AAABBB111222'
      minimum_protocol_version 'TLSv1'
      ssl_support_method 'sni-only'
    end
  end
end
```