### PR TITLE
Ensure securerandom is required.  Also do not pass empty Resources ar…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ mkmf.log
 
 keys
 VERSION
+attic

--- a/lib/convection/model/mixin/policy.rb
+++ b/lib/convection/model/mixin/policy.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 module Convection
   module Model
     module Mixin
@@ -91,13 +93,13 @@ module Convection
           def render
             {
               'Effect' => effect,
-              'Action' => action,
-              'Resource' => resource
-            }.tap do |statemant|
-              statemant['Sid'] = sid unless sid.nil?
-              statemant['Condition'] = condition unless condition.nil?
-              statemant['Principal'] = principal unless principal.nil?
-              statemant['NotPrincipal'] = not_principal unless not_principal.nil?
+              'Action' => action
+            }.tap do |statement|
+              statement['Sid'] = sid unless sid.nil?
+              statement['Condition'] = condition unless condition.nil?
+              statement['Principal'] = principal unless principal.nil?
+              statement['NotPrincipal'] = not_principal unless not_principal.nil?
+              statement['Resource'] = resource unless resource.empty? # Avoid failure in CF if empty Resources array is passed
             end
           end
         end


### PR DESCRIPTION
…ray in policy as CF with reject it

First - sometimes Convection fails as securerandom is not loaded.

Second, this template used to work:

```
module IAM
  IAM = Convection.template do
    description 'Something useful'

    iam_role 'MyRole' do
      path "/my/path"
      trust_ec2_instances
    end
  end
end
```

It generates this JSON:

```javascript
{
  "AWSTemplateFormatVersion": "2010-09-09",
  "Description": "Something useful",
  "Parameters": {
  },
  "Mappings": {
  },
  "Conditions": {
  },
  "Resources": {
    "MyRole": {
      "Type": "AWS::IAM::Role",
      "Properties": {
        "Path": "/my/path",
        "AssumeRolePolicyDocument": {
          "Version": "2012-10-17",
          "Statement": [
            {
              "Effect": "Allow",
              "Action": [
                "sts:AssumeRole"
              ],
              "Resource": [
              
              ],
              "Principal": {
                "Service": "ec2.amazonaws.com"
              }
            }
          ]
        }
      }
    }
  },
  "Outputs": {
  }
}
```

Yesterday this started to fail for me, with CF reporting the following:
```
    converge  Stack iam
create_in_progress  sirwin-cloud-iam: (AWS::CloudFormation::Stack/arn:aws:cloudformation:us-east-1:716756199562:stack/sirwin-cloud-iam/5c60c210-887e-11e5-a8f7-500150b34c7c) User Initiated
create_in_progress  MyRole: (AWS::IAM::Role/) 
create_failed  MyRole: (AWS::IAM::Role/) Has prohibited field Resource
```

With the code change, we will remove the `Resources` array if it is empty.  The resulting JSON looks like:

```javascript
{
  "AWSTemplateFormatVersion": "2010-09-09",
  "Description": "Something useful",
  "Parameters": {
  },
  "Mappings": {
  },
  "Conditions": {
  },
  "Resources": {
    "MyRole": {
      "Type": "AWS::IAM::Role",
      "Properties": {
        "Path": "/my/path/",
        "AssumeRolePolicyDocument": {
          "Version": "2012-10-17",
          "Statement": [
            {
              "Effect": "Allow",
              "Action": [
                "sts:AssumeRole"
              ],
              "Principal": {
                "Service": "ec2.amazonaws.com"
              }
            }
          ]
        }
      }
    }
  },
  "Outputs": {
  }
}
```

I'm not sure why this hasn't failed before now; I have deployed templates using this exact format for some weeks now.