### PR TITLE
Adds IAM Managed Policy

### DIFF
--- a/lib/convection/model/template/resource/aws_iam_managed_policy.rb
+++ b/lib/convection/model/template/resource/aws_iam_managed_policy.rb
@@ -1,0 +1,37 @@
+require_relative '../resource'
+
+module Convection
+  module Model
+    class Template
+      class Resource
+        ##
+        # AWS::IAM::ManagedPolicy
+        ##
+        class IAMManagedPolicy < Resource
+          extend Forwardable
+
+          type 'AWS::IAM::ManagedPolicy'
+          property :path, 'Path'
+          property :group, 'Groups', :type => :list
+          property :role, 'Roles', :type => :list
+          property :user, 'Users', :type => :list
+
+          attr_reader :document
+          def_delegators :@document, :allow, :deny, :id, :version, :statement
+
+          def initialize(*args)
+            super
+            @document = Model::Mixin::Policy.new(:template => @template)
+          end
+
+          def render
+            super.tap do |r|
+              document.render(r['Properties'])
+              r['Properties'].delete('PolicyName')
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This takes advantage of the existing Policy mixin.

A Managed policy is very similar to a role policy in that there is
deny/allow statements.  The difference is that a Managed policy has one
and only one policy.

For example this is what a policy might look like:

    iam_managed_policy 'MyPolicy' do
      path '/my/path'
      allow do
        resource ARN
        action 's3:GetObject'
      end
      group 's3-users'
    end