### PR TITLE
Fix S3 Versioning Property Name.

### DIFF
--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -17,7 +17,7 @@ module Convection
           property :lifecycle_configuration, 'LifecycleConfiguration'
           property :logging_configuration, 'LoggingConfiguration'
           property :notification_configuration, 'NotificationConfiguration'
-          property :version_configuration, 'VersionConfiguration'
+          property :versioning_configuration, 'VersioningConfiguration'
 
           def render(*args)
             super.tap do |resource|


### PR DESCRIPTION
Summary of Change
================
The S3 Property for Versioning was incorrect. This updates the property to match the name documented in the CloudFormation documentation.

Usage Example
============
Enabling Versioning:
```ruby
s3_bucket 'MyVersionedBucket' do
  bucket_name 'MyVersionedBucket'
  versioning_configuration('Status': 'Enabled')
end
```

Disabling Versioning:
```ruby
s3_bucket 'MyVersionedBucket' do
  bucket_name 'MyVersionedBucket'
  versioning_configuration('Status': 'Suspended')
end
```