### PR TITLE
Change egress_rule signature

### DIFF
--- a/example/security-groups.rb
+++ b/example/security-groups.rb
@@ -35,6 +35,43 @@ module Convection
 
         with_output
       end
+
+      ec2_security_group 'FoobarEgress' do
+        vpc stack.get('vpc', 'id')
+        description 'Foobar Ingress'
+
+        egress_rule(:tcp, 80, '0.0.0.0/0')
+        egress_rule(:tcp, 443, '0.0.0.0/0')
+
+        tag 'Name', "sg-foobar-egress-#{ stack.cloud }"
+        tag 'Service', 'foobar'
+        tag 'Resource', 'EC2'
+        tag 'Scope', 'private'
+        tag 'Stack', stack.cloud
+
+        with_output
+      end
+
+      ec2_security_group 'FoobarNoEgress' do
+        vpc stack.get('vpc', 'id')
+        description 'Foobar Ingress'
+
+        # By default, Cloud Formation adds a default egress rule that allows
+        # egress traffic on all ports and IP protocols to any location.  The default
+        # rule is removed only when you specify one or more egress rules.  If you want
+        # to remove the default rule and limit egress traffic to just the localhost,
+        # you can use the following rule:
+        # See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html
+        egress_rule(-1, nil, '127.0.0.1/32')
+
+        tag 'Name', "sg-foobar-noegress-#{ stack.cloud }"
+        tag 'Service', 'foobar'
+        tag 'Resource', 'EC2'
+        tag 'Scope', 'private'
+        tag 'Stack', stack.cloud
+
+        with_output
+      end
     end
   end
 end

--- a/example/security-groups.rb
+++ b/example/security-groups.rb
@@ -38,7 +38,7 @@ module Convection
 
       ec2_security_group 'FoobarEgress' do
         vpc stack.get('vpc', 'id')
-        description 'Foobar Ingress'
+        description 'Foobar Egress'
 
         egress_rule(:tcp, 80, '0.0.0.0/0')
         egress_rule(:tcp, 443, '0.0.0.0/0')
@@ -54,7 +54,7 @@ module Convection
 
       ec2_security_group 'FoobarNoEgress' do
         vpc stack.get('vpc', 'id')
-        description 'Foobar Ingress'
+        description 'Foobar No Egress'
 
         # By default, Cloud Formation adds a default egress rule that allows
         # egress traffic on all ports and IP protocols to any location.  The default

--- a/lib/convection/model/template/resource/aws_ec2_security_group.rb
+++ b/lib/convection/model/template/resource/aws_ec2_security_group.rb
@@ -19,11 +19,12 @@ module Convection
             security_group_ingress << rule
           end
 
-          def egress_rule(protocol = nil, port = nil, &block)
+          def egress_rule(protocol = nil, port = nil, destination = nil, &block)
             rule = Model::Template::Resource::EC2SecurityGroup::Rule.new("#{ name }EgressGroupRule", @template)
             rule.protocol = protocol unless protocol.nil?
             rule.from = port unless port.nil?
             rule.to = port unless port.nil?
+            rule.destination = destination unless destination.nil?
 
             rule.instance_exec(&block) if block
             security_group_egress << rule

--- a/lib/convection/model/template/resource/aws_ec2_security_group.rb
+++ b/lib/convection/model/template/resource/aws_ec2_security_group.rb
@@ -64,9 +64,9 @@ module Convection
             def render
               {
                 'IpProtocol' => Mixin::Protocol.lookup(protocol),
-                'FromPort' => from,
-                'ToPort' => to
               }.tap do |rule|
+                rule['FromPort'] = from unless from.nil?
+                rule['ToPort'] = to unless to.nil?
                 rule['CidrIp'] = source unless source.nil?
                 rule['CidrIp'] = destination unless destination.nil?
                 rule['DestinationSecurityGroupId'] = destination_group unless destination_group.nil?

--- a/lib/convection/model/template/resource/aws_ec2_security_group.rb
+++ b/lib/convection/model/template/resource/aws_ec2_security_group.rb
@@ -63,7 +63,7 @@ module Convection
 
             def render
               {
-                'IpProtocol' => Mixin::Protocol.lookup(protocol),
+                'IpProtocol' => Mixin::Protocol.lookup(protocol)
               }.tap do |rule|
                 rule['FromPort'] = from unless from.nil?
                 rule['ToPort'] = to unless to.nil?


### PR DESCRIPTION
This changes the `egress_rule` method signature to take a destination.
You have always been able to set the destination of an egress rule using a block like:
```ruby
egress_rule(:tcp, 22) { self.destination = '0.0.0.0/0' }
```

This makes it a little easier by allowing you to set it in the method itself like:
```ruby
egress_rule(:tcp, 22, '0.0.0.0/0')
```

Additionally, this PR changes security rules to only specify a port if a port is declared.  This allows specifying rules that have no to/from port, like the following rule that is [recommended](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html) by Amazon for removing the default egress rule.
```ruby
egress_rule(-1, nil, '127.0.0.1/32')
```