### PR TITLE
Add instance volumes

### DIFF
--- a/example/Cloudfile
+++ b/example/Cloudfile
@@ -1,7 +1,7 @@
 require_relative '../lib/convection'
 require_relative './vpc'
 require_relative './security-groups'
-require_relative './foobar'
+require_relative './instances'
 
 name 'convection-test'
 region 'us-east-1'
@@ -10,4 +10,4 @@ attribute 'vpc', 'subnet', '10.255.0.0/16'
 
 stack 'vpc', Convection::Demo::VPC
 stack 'security-groups', Convection::Demo::SECURITY_GROUPS
-stack 'foobar', Convection::Demo::FOOBAR
+stack 'instances', Convection::Demo::INSTANCES

--- a/example/foobar.rb
+++ b/example/foobar.rb
@@ -17,6 +17,77 @@ module Convection
         tag 'Service', 'foobar'
         tag 'Stack', stack.cloud
       end
+
+      #
+      # Create an instance with encrypted EBS mount point
+      # and an ephemeral volume
+      #
+
+      # Create a KMS encryption key to encrypt the volume
+      kms_key 'FoobarKmsKey' do
+        description 'Used to encrypt volumes'
+
+        # don't delete the key when this stack is deleted
+        deletion_policy 'Retain'
+
+        policy do
+          allow do
+            sid 'Enable IAM User Permissions'
+            principal :AWS => ["arn:aws:iam::#{MY_AWS_ACCOUNT_NUMBER}:root"]
+            action 'kms:*'
+            resource '*'
+          end
+        end
+      end
+
+      ec2_volume 'FoobarEncryptedVol' do
+        availability_zone 'us-east-1a'
+        size 20
+        volume_type :gp2
+
+        # encrypt with the key from this stack
+        encrypted true
+        kms_key fn_ref('FoobarKmsKey')
+
+        # don't delete the volume when this stack is deleted
+        deletion_policy 'Retain'
+
+        tag 'Name', 'Foobar Encrypted Volume'
+        tag 'Service', 'foobar'
+        tag 'Stack', stack.cloud
+      end
+
+      ec2_instance 'FoobarWithEncryptedVol' do
+        image_id stack['foobar-image']
+        instance_type 'm3.medium'
+        key_name 'production'
+        availability_zone 'us-east-1a'
+
+        # give the instance a static private IP and ensure
+        # it has a public ip regardless of subnet default setting
+        network_interface do
+          private_ip_address '10.1.2.3'
+          associate_public_ip_address true
+          security_group stack.get('security-groups', 'Foobar')
+          subnet stack.get('vpc', 'TargetVPCSubnetPublic3')
+        end
+
+        # mount the encrypted volume at /dev/xvdf
+        volume do
+          device '/dev/sdf'
+          volume_id fn_ref('FoobarEncryptedVol')
+        end
+
+        # mount an ephemeral drive at /dev/xvdc
+        block_device do
+          device '/dev/sdc'
+          virtual_name 'ephemeral0'
+        end
+
+        tag 'Name', 'Foobar Encrypted'
+        tag 'Service', 'foobar'
+        tag 'Stack', stack.cloud
+      end
     end
   end
 end

--- a/example/instances.rb
+++ b/example/instances.rb
@@ -2,7 +2,7 @@ require_relative '../lib/convection'
 
 module Convection
   module Demo
-    FOOBAR = Convection.template do
+    INSTANCES = Convection.template do
       description 'Demo Foobar'
 
       ec2_instance 'Foobar' do

--- a/lib/convection/model/template/resource.rb
+++ b/lib/convection/model/template/resource.rb
@@ -354,7 +354,7 @@ module Convection
             'Properties' => properties.map(true, &:render)
           }.tap do |resource|
             resource['DependsOn'] = @depends_on unless @depends_on.empty?
-            resource['DeletionPolicy'] = @deletion_policy if @deletion_policy
+            resource['DeletionPolicy'] = @deletion_policy unless @deletion_policy.nil?
             render_condition(resource)
           end
         end

--- a/lib/convection/model/template/resource.rb
+++ b/lib/convection/model/template/resource.rb
@@ -295,6 +295,7 @@ module Convection
           @template = parent.template
           @type = self.class.type
           @depends_on = []
+          @deletion_policy = nil
           @exist = false
 
           ## Instantiate properties
@@ -316,6 +317,14 @@ module Convection
         def depends_on(resource)
           @depends_on << (resource.is_a?(Resource) ? resource.name : resource)
         end
+
+        # rubocop:disable Style/TrivialAccessors
+        #   We don't want to use an accessor (e.g. deletion_policy=) because
+        #   this is a DSL method
+        def deletion_policy(deletion_policy)
+          @deletion_policy = deletion_policy
+        end
+        # rubocop:enable Style/TrivialAccessors
 
         def reference
           {
@@ -345,6 +354,7 @@ module Convection
             'Properties' => properties.map(true, &:render)
           }.tap do |resource|
             resource['DependsOn'] = @depends_on unless @depends_on.empty?
+            resource['DeletionPolicy'] = @deletion_policy if @deletion_policy
             render_condition(resource)
           end
         end

--- a/lib/convection/model/template/resource/aws_ec2_instance.rb
+++ b/lib/convection/model/template/resource/aws_ec2_instance.rb
@@ -22,6 +22,7 @@ module Convection
           property :src_dst_checks, 'SourceDestCheck'
           property :disable_api_termination, 'DisableApiTermination'
           property :network_interfaces, 'NetworkInterfaces', :type => :list
+          property :volumes, 'Volumes', :type => :list
 
           # Append a network interface to network_interfaces
           def network_interface(&block)
@@ -29,6 +30,13 @@ module Convection
             interface.instance_exec(&block) if block
             interface.device_index = network_interfaces.count.to_s
             network_interfaces << interface
+          end
+
+          # Append a volume to volumes
+          def volume(&block)
+            volume = ResourceProperty::EC2MountPoint.new(self)
+            volume.instance_exec(&block) if block
+            volumes << volume
           end
 
           def render(*args)

--- a/lib/convection/model/template/resource/aws_ec2_instance.rb
+++ b/lib/convection/model/template/resource/aws_ec2_instance.rb
@@ -22,6 +22,7 @@ module Convection
           property :src_dst_checks, 'SourceDestCheck'
           property :disable_api_termination, 'DisableApiTermination'
           property :network_interfaces, 'NetworkInterfaces', :type => :list
+          property :block_devices, 'BlockDeviceMappings', :type => :list
           property :volumes, 'Volumes', :type => :list
 
           # Append a network interface to network_interfaces
@@ -30,6 +31,13 @@ module Convection
             interface.instance_exec(&block) if block
             interface.device_index = network_interfaces.count.to_s
             network_interfaces << interface
+          end
+
+          # Append a block device mapping
+          def block_device(&block)
+            block_device = ResourceProperty::EC2BlockDeviceMapping.new(self)
+            block_device.instance_exec(&block) if block
+            block_devices << block_device
           end
 
           # Append a volume to volumes

--- a/lib/convection/model/template/resource/aws_ec2_volume.rb
+++ b/lib/convection/model/template/resource/aws_ec2_volume.rb
@@ -1,0 +1,32 @@
+require_relative '../resource'
+
+module Convection
+  module Model
+    class Template
+      class Resource
+        ##
+        # AWS::EC2::Volume
+        ##
+        class EC2Volume < Resource
+          include Model::Mixin::Taggable
+
+          type 'AWS::EC2::Volume'
+          property :auto_enable_io, 'AutoEnableIO'
+          property :availability_zone, 'AvailabilityZone'
+          property :encrypted, 'Encrypted'
+          property :iops, 'Iops'
+          property :kms_key, 'KmsKeyId'
+          property :size, 'Size'
+          property :snapshot, 'SnapshotId'
+          property :volume_type, 'VolumeType'
+
+          def render(*args)
+            super.tap do |resource|
+              render_tags(resource)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource/aws_kms_key.rb
+++ b/lib/convection/model/template/resource/aws_kms_key.rb
@@ -1,0 +1,38 @@
+require_relative '../resource'
+
+module Convection
+  module DSL
+    module Template
+      module Resource
+        ## Role DSL
+        module KmsKey
+          def policy(&block)
+            add_policy = Model::Mixin::Policy.new(:name => 'kms_policy', :template => @template)
+            add_policy.instance_exec(&block) if block
+            self.key_policy = add_policy.document
+          end
+        end
+      end
+    end
+  end
+
+  module Model
+    class Template
+      class Resource
+        ##
+        # AWS::KMS::Key
+        ##
+        class KmsKey < Resource
+          include DSL::Template::Resource::KmsKey
+
+          type 'AWS::KMS::Key'
+          property :description, 'Description'
+          property :enabled, 'Enabled'
+          property :enabled_key_rotation, 'EnabledKeyRotation'
+          alias key_rotation enabled_key_rotation
+          property :key_policy, 'KeyPolicy'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_ec2_block_device_mapping.rb
+++ b/lib/convection/model/template/resource_property/aws_ec2_block_device_mapping.rb
@@ -1,0 +1,25 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-mapping.html
+        # EC2 Block Device Mapping Property Type}
+        class EC2BlockDeviceMapping < ResourceProperty
+          property :device_name, 'DeviceName'
+          alias device device_name
+          property :ebs, 'Ebs'
+          property :no_device, 'NoDevice'
+          property :virtual_name, 'VirtualName'
+
+          def ebs(&block)
+            ebs = ResourceProperty::EC2BlockStoreBlockDevice.new(self)
+            ebs.instance_exec(&block) if block
+            properties['Ebs'].set(config)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_ec2_block_store_block_device.rb
+++ b/lib/convection/model/template/resource_property/aws_ec2_block_store_block_device.rb
@@ -1,0 +1,22 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-template.html
+        # EC2 Block Store Block Device Property Type}
+        class EC2BlockStoreBlockDevice < ResourceProperty
+          property :delete_on_termination, 'DeleteOnTermination'
+          property :encrypted, 'Encrypted'
+          property :iops, 'Iops'
+          property :snapshot, 'SnapshotId'
+          property :volume_size, 'VolumeSize'
+          alias size volume_size
+          property :volume_type, 'VolumeType'
+          alias type volume_type
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_ec2_mount_point.rb
+++ b/lib/convection/model/template/resource_property/aws_ec2_mount_point.rb
@@ -1,0 +1,16 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-mount-point.html
+        # EC2 MountPoint Property Type}
+        class EC2MountPoint < ResourceProperty
+          property :device, 'Device'
+          property :volume_id, 'VolumeId'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds support for adding volumes to EC2 instances.  It allows adding ephemeral instances, unencrypted EBS instances, and encrypted EBS instances.

The easiest way to see these changes is in the `example/foobar.rb` file.  I'll copy/paste the relevant/new sections here:

```ruby
# Create a KMS encryption key to encrypt the volume
kms_key 'FoobarKmsKey' do
  description 'Used to encrypt volumes'
  
  # don't delete the key when this stack is deleted
  deletion_policy 'Retain'

  policy do
    allow do
      sid 'Enable IAM User Permissions'
      principal :AWS => ["arn:aws:iam::#{MY_AWS_ACCOUNT_NUMBER}:root"]
      action 'kms:*'
      resource '*'
    end
  end
end

ec2_volume 'FoobarEncryptedVol' do
  availability_zone 'us-east-1a'
  size 20
  volume_type :gp2

  # encrypt with the key from this stack
  encrypted true
  kms_key fn_ref('FoobarKmsKey')

  # take a snapshot of the volume when this stack is deleted
  deletion_policy 'Snapshot'
end

ec2_instance 'FoobarWithEncryptedVol' do
  image_id stack['foobar-image']
  instance_type 'm3.medium'
  availability_zone 'us-east-1a'

  # mount the encrypted volume at /dev/xvdf
  volume do
    device '/dev/sdf'
    volume_id fn_ref('FoobarEncryptedVol')
  end

  # mount an ephemeral drive at /dev/xvdc
  block_device do
    device '/dev/sdc'
    virtual_name 'ephemeral0'
  end
end
```

The best way to review this is commit by commit:
* b21ac66009d87fb35abc9e5de09815a26f20eaf5 - adds support for the `DeletionPolicy` attribute.  This is supported by almost all resources and controls what happens to the resource when the stack is deleted.  This is helpful to allow encryption keys or important volumes to stick around after a stack is deleted.  See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
* 047598cac1f3cb6de8f4b136310f0a33126af873 - `kms_key` allows creating a new KMS encryption key and corresponding policy.  See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kms-key.html
* 7d6c93d019f15b86c3c43eb980ff8aaeb01549fd - `ec2_volume` allows creating a standalone EBS volume.  The volume can be attached to existing instances or new instances with the new `volume` attribute.  See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volume.html and http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-volumes
* 9b99b08b58e00834ad8532872d9f9bf7a8c4d73b - A new `block_device` allows attaching ephemeral volumes or net-new EBS volumes.  The main difference between block_device and volume is block_device creates the volume as part of launch, and volume attaches an existing volume.  See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-blockdevicemappings