### PR TITLE
Add support for NAT gateways

### DIFF
--- a/lib/convection/model/template/resource/aws_ec2_eip.rb
+++ b/lib/convection/model/template/resource/aws_ec2_eip.rb
@@ -1,0 +1,18 @@
+require_relative '../resource'
+
+module Convection
+  module Model
+    class Template
+      class Resource
+        ##
+        # AWS::EC2::EIP
+        ##
+        class EC2EIP < Resource
+          type 'AWS::EC2::EIP'
+          property :instance, 'InstanceId'
+          property :domain, 'Domain'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource/aws_ec2_nat_gateway.rb
+++ b/lib/convection/model/template/resource/aws_ec2_nat_gateway.rb
@@ -1,0 +1,18 @@
+require_relative '../resource'
+
+module Convection
+  module Model
+    class Template
+      class Resource
+        ##
+        # AWS::EC2::NatGateway
+        ##
+        class EC2NatGateway < Resource
+          type 'AWS::EC2::NatGateway'
+          property :allocation_id, 'AllocationId'
+          property :subnet, 'SubnetId'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource/aws_ec2_route.rb
+++ b/lib/convection/model/template/resource/aws_ec2_route.rb
@@ -12,6 +12,7 @@ module Convection
           property :route_table_id, 'RouteTableId'
           property :destination, 'DestinationCidrBlock'
           property :gateway, 'GatewayId'
+          property :nat_gateway, 'NatGatewayId'
           property :instance, 'InstanceId'
           property :interface, 'NetworkInterfaceId'
           property :peer, 'VpcPeeringConnectionId'


### PR DESCRIPTION
This allows you to create a NAT gateways using AWS' new [NAT Gateway](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html) support.

A NAT Gateway looks like:
```ruby
# Create an Elastic IP that will be used by the NAT gateway
ec2_eip "NatGatewayIP1" do
  domain 'vpc'
end

# Create the NAT gateway.  The gateway must go in a public subnet
# that has an internet gateway attached.
ec2_nat_gateway "NatGateway1" do
  subnet fn_ref("TargetVPCSubnetPublic1")
  allocation_id get_att("NatGatewayIP1", 'AllocationId')
end

# Set the default route in the private route table to use the NAT Gateway
ec2_route "NatGatewayRoute1" do
  destination '0.0.0.0/0'
  nat_gateway fn_ref("NatGateway1")
  route_table_id private_table
end
```