### PR TITLE
tag support for elasticache cluster and replication group

### DIFF
--- a/lib/convection/model/template/resource/aws_elasticache_cluster.rb
+++ b/lib/convection/model/template/resource/aws_elasticache_cluster.rb
@@ -8,6 +8,8 @@ module Convection
         # AWS::ElastiCache::CacheCluster
         ##
         class ElastiCacheCluster < Resource
+          include Mixin::Taggable
+          
           type 'AWS::ElastiCache::CacheCluster', :elasticache_cache_cluster
           property :auto_minor_version_upgrade, 'AutoMinorVersionUpgrade'
           property :cache_node_type, 'CacheNodeType'
@@ -19,6 +21,13 @@ module Convection
           property :engine_version, 'EngineVersion'
           property :num_cache_nodes, 'NumCacheNodes'
           property :vpc_security_group_ids, 'VpcSecurityGroupIds'
+
+          def render(*args)
+            super.tap do |resource|
+              render_tags(resource)
+            end
+          end
+
         end
       end
     end

--- a/lib/convection/model/template/resource/aws_elasticache_cluster.rb
+++ b/lib/convection/model/template/resource/aws_elasticache_cluster.rb
@@ -9,7 +9,7 @@ module Convection
         ##
         class ElastiCacheCluster < Resource
           include Mixin::Taggable
-          
+
           type 'AWS::ElastiCache::CacheCluster', :elasticache_cache_cluster
           property :auto_minor_version_upgrade, 'AutoMinorVersionUpgrade'
           property :cache_node_type, 'CacheNodeType'
@@ -27,7 +27,6 @@ module Convection
               render_tags(resource)
             end
           end
-
         end
       end
     end

--- a/lib/convection/model/template/resource/aws_elasticache_replication_group.rb
+++ b/lib/convection/model/template/resource/aws_elasticache_replication_group.rb
@@ -8,6 +8,8 @@ module Convection
         # AWS::ElastiCache::ReplicationGroup
         ##
         class ElastiCacheReplicationGroup < Resource
+          include Mixin::Taggable
+
           type 'AWS::ElastiCache::ReplicationGroup', :elasticache_replication_group
           property :auto_failover_enabled, 'AutomaticFailoverEnabled'
           property :auto_minor_version_upgrade, 'AutoMinorVersionUpgrade'
@@ -27,6 +29,13 @@ module Convection
           property :snapshot_arns, 'SnapshotArns', :type => :list
           property :snapshot_retention_limit, 'SnapshotRetentionLimit'
           property :snapshot_window, 'SnapshotWindow'
+
+          def render(*args)
+            super.tap do |resource|
+              render_tags(resource)
+            end
+          end
+
         end
       end
     end

--- a/lib/convection/model/template/resource/aws_elasticache_replication_group.rb
+++ b/lib/convection/model/template/resource/aws_elasticache_replication_group.rb
@@ -35,7 +35,6 @@ module Convection
               render_tags(resource)
             end
           end
-
         end
       end
     end


### PR DESCRIPTION
This pr is for adding the mixin and render method to add tag support to elasticache clusters and elasticache replication groups