### PR TITLE
Fix support for Lambdas

### DIFF
--- a/lib/convection/model/template/resource/aws_lambda_function.rb
+++ b/lib/convection/model/template/resource/aws_lambda_function.rb
@@ -9,12 +9,28 @@ module Convection
         ##
         class Lambda < Resource
           type 'AWS::Lambda::Function'
-          property :code, 'Code'
+          property :function_code, 'Code'
           property :description, 'Description'
           property :handler, 'Handler'
           property :memory_size, 'MemorySize'
-          property :runtime, 'Runtime', :equal_to => ['nodejs', 'java8', 'python2.7']
+          property :runtime, 'Runtime', :equal_to => ['nodejs', 'nodejs4.3', 'java8', 'python2.7']
           property :timeout, 'Timeout'
+          property :role, 'Role'
+          property :vpc_cfg, 'VpcConfig'
+
+          # Add code block
+          def code(&block)
+            function_code = ResourceProperty::LambdaFunctionCode.new(self)
+            function_code.instance_exec(&block) if block
+            properties['Code'].set(function_code)
+          end
+
+          # Add vpc_config block
+          def vpc_config(&block)
+            vpc_cfg = ResourceProperty::LambdaVpcConfig.new(self)
+            vpc_cfg.instance_exec(&block) if block
+            properties['VpcConfig'].set(vpc_cfg)
+          end
         end
       end
     end

--- a/lib/convection/model/template/resource_property/aws_lambda_function_code.rb
+++ b/lib/convection/model/template/resource_property/aws_lambda_function_code.rb
@@ -1,0 +1,15 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html}
+        class LambdaFunctionCode < ResourceProperty
+          property :s3_bucket, 'S3Bucket'
+          property :s3_key, 'S3Key'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_lambda_vpc_config.rb
+++ b/lib/convection/model/template/resource_property/aws_lambda_vpc_config.rb
@@ -1,0 +1,15 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-vpcconfig.html}
+        class LambdaVpcConfig < ResourceProperty
+          property :security_groups, 'SecurityGroupIds', :type => :list
+          property :subnets, 'SubnetIds', :type => :list
+        end
+      end
+    end
+  end
+end

--- a/test/convection/model/test_lambdas.rb
+++ b/test/convection/model/test_lambdas.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+require 'json'
+require 'pp'
+
+class TestLambdas < Minitest::Test
+  def setup
+    @template = ::Convection.template do
+      description 'Conditions Test Template'
+
+      lambda_function 'TestLambda' do
+        description 'Test description'
+        handler 'index.handler'
+        runtime 'nodejs'
+        role 'arn:aws:x:y:z'
+
+        code do
+          s3_bucket 'testbucket'
+          s3_key 'testkey'
+        end
+
+        vpc_config do
+          security_groups %w(group1 group2)
+          subnets %w(subnet1a subnet1b)
+        end
+      end
+    end
+  end
+
+  def from_json
+    JSON.parse(@template.to_json)
+  end
+
+  def test_lambda
+    json = from_json['Resources']['TestLambda']['Properties']
+
+    code = json['Code']
+    assert_equal 'testbucket', code['S3Bucket']
+    assert_equal 'testkey', code['S3Key']
+
+    assert_equal 'arn:aws:x:y:z', json['Role']
+
+    vpc = json['VpcConfig']
+    refute vpc.nil?, 'VpcConfig not present in generated template'
+
+    secgroups = vpc['SecurityGroupIds']
+    assert secgroups.is_a?(Array), 'SecurityGroupIds is not an array'
+    assert_equal 2, secgroups.size
+
+    subnets = vpc['SubnetIds']
+    assert subnets.is_a?(Array), 'SubnetIds is not an array'
+    assert_equal 2, subnets.size
+  end
+end


### PR DESCRIPTION
Added full support for S3 bucket reference, and VPC integration.  Unit test added, showing we can support:

```
      lambda_function 'TestLambda' do
        description 'Test description'
        handler 'index.handler'
        runtime 'nodejs'
        role 'arn:aws:x:y:z'

        code do
          s3_bucket 'testbucket'
          s3_key 'testkey'
        end

        vpc_config do
          security_groups %w(group1 group2)
          subnets %w(subnet1a subnet1b)
        end
      end
```