### PR TITLE
Create a simple directory service (SimpleAD) resource

### DIFF
--- a/lib/convection/model/template/resource/aws_directory_service_simple_ad.rb
+++ b/lib/convection/model/template/resource/aws_directory_service_simple_ad.rb
@@ -1,0 +1,23 @@
+require_relative '../resource'
+
+module Convection
+  module Model
+    class Template
+      class Resource
+        ##
+        # AWS::DirectoryService::SimpleAD
+        ##
+        class DirectoryServiceSimpleAD < Resource
+          type 'AWS::DirectoryService::SimpleAD', :directoryservice_simple_ad
+          property :description, 'Description'
+          property :enable_sso, 'EnableSso'
+          property :name, 'Name'
+          property :password, 'Password'
+          property :short_name, 'ShortName'
+          property :size, 'Size'
+          property :vpc_settings, 'VpcSettings', :type => :hash
+        end
+      end
+    end
+  end
+end

--- a/test/convection/model/test_directory_service.rb
+++ b/test/convection/model/test_directory_service.rb
@@ -34,7 +34,7 @@ describe 'AWS::DirectoryService' do
 
   def simple_ad_json
     JSON.parse(simple_ad_template.to_json)
-      .fetch('Resources')
-      .fetch('SimpleActiveDirectory')
+        .fetch('Resources')
+        .fetch('SimpleActiveDirectory')
   end
 end

--- a/test/convection/model/test_directory_service.rb
+++ b/test/convection/model/test_directory_service.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+require 'json'
+
+describe 'AWS::DirectoryService' do
+  let(:simple_ad_template) do
+    ::Convection.template do
+      directoryservice_simple_ad 'SimpleActiveDirectory' do
+        description 'Example simple AD'
+        enable_sso false
+        name 'ExampleSimpleAD'
+        password 'directory.password'
+        short_name 'directory.name'
+        size 'Small'
+
+        vpc_settings 'SubnetIds', ['subnet-deadb33f']
+        vpc_settings 'VpcId', 'vpc-deadb33f'
+      end
+    end
+  end
+
+  describe 'SimpleAD' do
+    it 'sets VpcSettings.SubnetIds' do
+      vpc_settings = simple_ad_json.fetch('Properties').fetch('VpcSettings')
+      assert_equal vpc_settings.fetch('SubnetIds'), ['subnet-deadb33f']
+    end
+
+    it 'sets VpcSettings.VpcId' do
+      vpc_settings = simple_ad_json.fetch('Properties').fetch('VpcSettings')
+      assert_equal vpc_settings.fetch('VpcId'), 'vpc-deadb33f'
+    end
+  end
+
+  private
+
+  def simple_ad_json
+    JSON.parse(simple_ad_template.to_json)
+      .fetch('Resources')
+      .fetch('SimpleActiveDirectory')
+  end
+end


### PR DESCRIPTION
ping @jmanero-r7 @athompson-r7 @abegley-r7 @simonirwin-r7 

---

# Before
```ruby
resource 'SimpleActiveDirectory' do
  type 'AWS::DirectoryService::SimpleAD'
  property 'Description',  'Example simple AD'
  property 'EnableSso',    false
  property 'Name',         'ExampleSimpleAD'
  property 'Password',     'directory.password'
  property 'ShortName',    'directory.name'
  property 'Size',         'Small'

  property 'VpcSettings', {
    'SubnetIds' => ['subnet-deadb33f'],
    'VpcId'     => 'vpc-deadb33f'
  }
end
```

# After
```ruby
directoryservice_simple_ad 'SimpleActiveDirectory' do
  description  'Example simple AD'
  enable_sso   false
  name         'ExampleSimpleAD'
  password     'directory.password'
  short_name   'directory.name'
  size         'Small'

  vpc_settings 'SubnetIds', ['subnet-deadb33f']
  vpc_settings 'VpcId', 'vpc-deadb33f'
end
```