### PR TITLE
Generic trust relationship

### DIFF
--- a/lib/convection/model/template/resource/aws_iam_role.rb
+++ b/lib/convection/model/template/resource/aws_iam_role.rb
@@ -24,6 +24,16 @@ module Convection
             @template.resources[profile.name] = profile
           end
 
+          ## Add a canned trust policy for any AWS service
+          def trust_service(name, &block)
+            @trust_relationship = Model::Mixin::Policy.new(:name => "trust-#{name}-service", :template => @template)
+            trust_relationship.allow do
+              action 'sts:AssumeRole'
+              principal :Service => "#{name}.amazonaws.com"
+            end
+            trust_relationship.instance_exec(&block) if block
+          end
+
           ## Add a canned trust policy for EC2 instances
           def trust_ec2_instances(&block)
             @trust_relationship = Model::Mixin::Policy.new(:name => 'trust-ec2-instances', :template => @template)

--- a/test/convection/model/test_trust.rb
+++ b/test/convection/model/test_trust.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+require 'json'
+require 'pp'
+
+class TestTrust < Minitest::Test
+  def setup
+    @template = ::Convection.template do
+      description 'Trust Test Template'
+
+      iam_role 'FooRole' do
+        trust_service 'bar'
+      end
+    end
+  end
+
+  def from_json
+    JSON.parse(@template.to_json)
+  end
+
+  def test_trust
+    json = from_json['Resources']['FooRole']['Properties']
+    doc = json['AssumeRolePolicyDocument']
+    refute doc.nil?, 'No policy document present in JSON'
+    stmt = doc['Statement']
+
+    trust_bar = stmt.any? { |s| s['Principal']['Service'] == 'bar.amazonaws.com' }
+    assert_equal true, trust_bar, 'Expected to find [bar.amazonaws.com] in document'
+  end
+end

--- a/test/convection/model/test_trust.rb
+++ b/test/convection/model/test_trust.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 require 'json'
-require 'pp'
 
 class TestTrust < Minitest::Test
   def setup


### PR DESCRIPTION
Within an `iam_role` definition, I can now specify:

`trust_ec2_instances`
or
`trust_service 'ec2'`

This means any other services can be supported without an explicit `trust_XXX` method. e.g.

`trust_service 'lambda'`

I need the Lambda trust method above.  This will generate:

```
    "AssumeRolePolicyDocument": {
          "Version": "2012-10-17",
          "Statement": [
            {
              "Effect": "Allow",
              "Action": [
                "sts:AssumeRole"
              ],
              "Principal": {
                "Service": "lambda.amazonaws.com"
              }
            }
          ]
        }
```