### PR TITLE
Reimplement AWS trust service methods after merging #92

### DIFF
--- a/lib/convection/model/template/resource/aws_iam_role.rb
+++ b/lib/convection/model/template/resource/aws_iam_role.rb
@@ -48,7 +48,6 @@ module Convection
           ## Add a canned trust policy for EMR
           def trust_emr(&block)
             trust_service('elasticmapreduce', 'trust-emr', &block)
-            trust_service('', '', &block)
           end
 
           ## Add a canned trust policy for Cloudtrail

--- a/lib/convection/model/template/resource/aws_iam_role.rb
+++ b/lib/convection/model/template/resource/aws_iam_role.rb
@@ -25,8 +25,9 @@ module Convection
           end
 
           ## Add a canned trust policy for any AWS service
-          def trust_service(name, &block)
-            @trust_relationship = Model::Mixin::Policy.new(:name => "trust-#{name}-service", :template => @template)
+          def trust_service(name, policy_name = nil, &block)
+            policy_name ||= "trust-#{name}-service"
+            @trust_relationship = Model::Mixin::Policy.new(:name => policy_name, :template => @template)
             trust_relationship.allow do
               action 'sts:AssumeRole'
               principal :Service => "#{name}.amazonaws.com"
@@ -36,49 +37,23 @@ module Convection
 
           ## Add a canned trust policy for EC2 instances
           def trust_ec2_instances(&block)
-            @trust_relationship = Model::Mixin::Policy.new(:name => 'trust-ec2-instances', :template => @template)
-            trust_relationship.allow do
-              action 'sts:AssumeRole'
-              principal :Service => 'ec2.amazonaws.com'
-            end
-            trust_relationship.instance_exec(&block) if block
-            trust_relationship
+            trust_service('ec2', 'trust-ec2-instances', &block)
           end
 
           ## Add a canned trust policy for Flow Logs
           def trust_flow_logs(&block)
-            @trust_relationship = Model::Mixin::Policy.new(:name => 'trust-flow-logs', :template => @template)
-            trust_relationship.allow do
-              action 'sts:AssumeRole'
-              principal :Service => 'vpc-flow-logs.amazonaws.com'
-            end
-            trust_relationship.instance_exec(&block) if block
-            trust_relationship
+            trust_service('vpc-flow-logs', 'trust-flow-logs', &block)
           end
 
           ## Add a canned trust policy for EMR
           def trust_emr(&block)
-            @trust_relationship = Model::Mixin::Policy.new(:name => 'trust-emr', :template => @template)
-            trust_relationship.allow do
-              action 'sts:AssumeRole'
-              principal :Service => 'elasticmapreduce.amazonaws.com'
-            end
-            trust_relationship.instance_exec(&block) if block
-            trust_relationship
+            trust_service('elasticmapreduce', 'trust-emr', &block)
+            trust_service('', '', &block)
           end
 
           ## Add a canned trust policy for Cloudtrail
           def trust_cloudtrail(&block)
-            @trust_relationship =
-              Model::Mixin::Policy.new(:name => 'trust-cloudtrail-instances', :template => @template)
-
-            trust_relationship.allow do
-              action 'sts:AssumeRole'
-              principal :Service => 'cloudtrail.amazonaws.com'
-            end
-
-            trust_relationship.instance_exec(&block) if block
-            trust_relationship
+            trust_service('cloudtrail', 'trust-cloudtrail-instances', &block)
           end
 
           ## Add a policy to allow instance to self-terminate


### PR DESCRIPTION
Closes #93.

---

~~**NOTE**: These changes will update the names for most of these policies.~~

*edit*: Changes to maintain the policy names were implemented.