### PR TITLE
Create a CloudWatch events rule resource

### DIFF
--- a/lib/convection/model/template/resource/aws_events_rule.rb
+++ b/lib/convection/model/template/resource/aws_events_rule.rb
@@ -1,0 +1,24 @@
+require_relative '../resource'
+
+module Convection
+  module Model
+    class Template
+      class Resource
+        ##
+        # AWS::Events::Rule
+        ##
+        class EventsRule < Resource
+          type 'AWS::Events::Rule'
+          property :description, 'Description'
+          property :domain, 'Domain'
+          property :event_pattern, 'EventPattern', :type => :hash
+          property :name, 'Name'
+          property :role_arn, 'RoleArn'
+          property :schedule_expression, 'ScheduleExpression'
+          property :state, 'State'
+          property :targets, 'Targets', :type => :array
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource/aws_events_rule.rb
+++ b/lib/convection/model/template/resource/aws_events_rule.rb
@@ -16,7 +16,13 @@ module Convection
           property :role_arn, 'RoleArn'
           property :schedule_expression, 'ScheduleExpression'
           property :state, 'State'
-          property :target, 'Targets', :type => :array
+          property :targets, 'Targets', :type => :array
+
+          def target(&block)
+            target = ResourceProperty::EventsRuleTarget.new(self)
+            target.instance_exec(&block) if block
+            targets << target
+          end
         end
       end
     end

--- a/lib/convection/model/template/resource/aws_events_rule.rb
+++ b/lib/convection/model/template/resource/aws_events_rule.rb
@@ -16,7 +16,7 @@ module Convection
           property :role_arn, 'RoleArn'
           property :schedule_expression, 'ScheduleExpression'
           property :state, 'State'
-          property :targets, 'Targets', :type => :array
+          property :target, 'Targets', :type => :array
         end
       end
     end

--- a/lib/convection/model/template/resource_property/aws_events_rule_target.rb
+++ b/lib/convection/model/template/resource_property/aws_events_rule_target.rb
@@ -1,0 +1,18 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-events-rule-target.html
+        # CloudWatch Events Rule Target}
+        class EventsRuleTarget < ResourceProperty
+          property :arn, 'Arn'
+          property :id, 'Id'
+          property :input, 'Input'
+          property :input_path, 'InputPath'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a resource for `AWS::Events::Rule` to enable Convection support of creating CloudWatch event rules.

See also [AWS::Events::Rule](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-eventpattern).