### PR TITLE
VPC Endpoint error when generating the S3 service name

### DIFF
--- a/lib/convection/model/template/resource/aws_ec2_vpc_endpoint.rb
+++ b/lib/convection/model/template/resource/aws_ec2_vpc_endpoint.rb
@@ -26,7 +26,7 @@ module Convection
           end
 
           def service(val)
-            properties['ServiceName'].set(join('', 'com.amazonaws.', fn_ref('AWS::Region'), val))
+            properties['ServiceName'].set(join('.', 'com.amazonaws', fn_ref('AWS::Region'), val))
           end
 
           def render

--- a/test/convection/model/test_vpc_endpoint.rb
+++ b/test/convection/model/test_vpc_endpoint.rb
@@ -41,6 +41,8 @@ class TestVpcEndpoint < Minitest::Test
     refute s3_string_arr.nil?, 'ServiceName value is not specified as a string array'
 
     assert s3_string_arr.is_a? Array
+    assert_equal '.', s3_string_arr[0]
+
     s3_path_as_array = s3_string_arr[1]
     refute s3_path_as_array.nil?, "The path for S3 should be defined as an array in #{s3_string_arr}"
 


### PR DESCRIPTION
The join was creating something like this:

`com.amazonaws.us-east-1s3`

It should be:

`com.amazonaws.us-east-1.s3`