### PR TITLE
Feature: diff verbosity options

### DIFF
--- a/bin/convection
+++ b/bin/convection
@@ -27,7 +27,8 @@ module Convection
     end
 
     desc 'diff', 'Show changes that will be applied by converge'
-    option :verbose, :type => :boolean, :aliases => :v
+    option :verbose, :type => :boolean, :aliases => '--v'
+    option :'very-verbose', :type => :boolean, :aliases => '--vv'
     def diff
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
 
@@ -35,13 +36,15 @@ module Convection
 
       @cloud.diff do |d|
         if d.is_a? Model::Event
-          if options[:verbose] && d.name == :compare
+          if options[:'very-verbose']
             say_status(*d.to_thor)
+          elsif options[:verbose]
+            say_status(*d.to_thor) if d.name == :compare
           end
           last_event = d
         elsif d.is_a? Model::Diff
-          if !options[:verbose] && !last_event.nil?
-            say_status(*last_event.to_thor)
+          if !options[:'very-verbose'] && !options[:verbose]
+            say_status(*last_event.to_thor) unless last_event.nil?
             last_event = nil
           end
           say_status(*d.to_thor)

--- a/bin/convection
+++ b/bin/convection
@@ -48,6 +48,8 @@ module Convection
             last_event = nil
           end
           say_status(*d.to_thor)
+        else
+          say_status(*d.to_thor)
         end
       end
     end

--- a/bin/convection
+++ b/bin/convection
@@ -27,8 +27,8 @@ module Convection
     end
 
     desc 'diff', 'Show changes that will be applied by converge'
-    option :verbose, :type => :boolean, :aliases => '--v'
-    option :'very-verbose', :type => :boolean, :aliases => '--vv'
+    option :verbose, :type => :boolean, :aliases => '--v', :desc => 'Show stack progress'
+    option :'very-verbose', :type => :boolean, :aliases => '--vv', :desc => 'Show unchanged stacks'
     def diff
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
 

--- a/bin/convection
+++ b/bin/convection
@@ -27,15 +27,20 @@ module Convection
     end
 
     desc 'diff', 'Show changes that will be applied by converge'
+    option :verbose, :type => :boolean, :aliases => :v
     def diff
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
 
       last_event = nil
+
       @cloud.diff do |d|
         if d.is_a? Model::Event
+          if options[:verbose] && d.name == :compare
+            say_status(*d.to_thor)
+          end
           last_event = d
-        else
-          unless last_event.nil?
+        elsif d.is_a? Model::Diff
+          if !options[:verbose] && !last_event.nil?
             say_status(*last_event.to_thor)
             last_event = nil
           end

--- a/bin/convection
+++ b/bin/convection
@@ -29,7 +29,19 @@ module Convection
     desc 'diff', 'Show changes that will be applied by converge'
     def diff
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
-      @cloud.diff { |d| say_status(*d.to_thor) }
+
+      last_event = nil
+      @cloud.diff do |d|
+        if d.is_a? Model::Event
+          last_event = d
+        else
+          unless last_event.nil?
+            say_status(*last_event.to_thor)
+            last_event = nil
+          end
+          say_status(*d.to_thor)
+        end
+      end
     end
 
     desc 'print STACK', 'Print the rendered template for STACK'


### PR DESCRIPTION
This adds verbosity options to the diff command.

~~~text
$> convection help diff
Usage:
  convection diff

Options:
  --v, [--verbose], [--no-verbose]             # Show stack progress
  --vv, [--very-verbose], [--no-very-verbose]  # Show unchanged stacks
      [--cloudfile=CLOUDFILE]
                                               # Default: Cloudfile

Show changes that will be applied by converge
~~~

The default behavior is to only show stacks that have changes. If nothing changes, the diff command won't output anything. Stacks that have changes show both the "compare  Compare local state of stack XXX with remote template" line and the changes.

~~~text
$> convection diff
  compare  Compare local state of stack YYY with remote template
   create  .Resources.Role.Properties.Policies.0.PolicyDocument.Statement.2.Effect: Allow
   create  .Resources.Role.Properties.Policies.0.PolicyDocument.Statement.2.Action.0: s3:ListBucket
   create  .Resources.Role.Properties.Policies.0.PolicyDocument.Statement.2.Action.2: s3:GetObject
~~~

The `--verbose` flag shows stack progress, so you get a "compare  Compare local state of stack XXX with remote template" line for each stack.

~~~text
$> convection diff --verbose
  compare  Compare local state of stack XXX with remote template
  compare  Compare local state of stack YYY with remote template
   create  .Resources.Role.Properties.Policies.0.PolicyDocument.Statement.2.Effect: Allow
   create  .Resources.Role.Properties.Policies.0.PolicyDocument.Statement.2.Action.0: s3:ListBucket
   create  .Resources.Role.Properties.Policies.0.PolicyDocument.Statement.2.Action.2: s3:GetObject
  compare  Compare local state of stack ZZZ with remote template
~~~

The `--very-verbose` flag also shows unchanged stacks, so you also get an "unchanged  Stack XXX Has no changes" line for each stack that hasn't changed. This matches the existing output prior to this pull request.

~~~text
$> convection diff --very-verbose
  compare  Compare local state of stack XXX with remote template
unchanged  Stack XXX Has no changes
  compare  Compare local state of stack YYY with remote template
   create  .Resources.Role.Properties.Policies.0.PolicyDocument.Statement.2.Effect: Allow
   create  .Resources.Role.Properties.Policies.0.PolicyDocument.Statement.2.Action.0: s3:ListBucket
   create  .Resources.Role.Properties.Policies.0.PolicyDocument.Statement.2.Action.2: s3:GetObject
  compare  Compare local state of stack ZZZ with remote template
unchanged  Stack ZZZ Has no changes
~~~

Aliases are provided as `--v` and `--vv` instead of the usual UNIX convection of `-v` and `-vv` because of a limitation in Thor where options that start with a single dash may only be one letter long.