### PR TITLE
👮🏽 Constrain RuboCop to ~> 0.40.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :development do
   gem 'bundler', '~> 1.7'
   gem 'minitest'
   gem 'rake', '~> 10.0'
-  gem 'rubocop', '~> 0.34'
+  gem 'rubocop', '~> 0.40.0'
   gem 'simplecov'
   gem 'thor-scmversion', '= 1.7.0'
 end


### PR DESCRIPTION
This will prevent TravisCI builds from failing when RuboCop rules change
drastically in MINOR versions. PATCH versions will still be allowed to
be pulled automatically.

👮 👮 👮 

Fix #124.
See also #123.