### PR TITLE
Feature: Diff individual stacks

### DIFF
--- a/bin/convection
+++ b/bin/convection
@@ -26,15 +26,15 @@ module Convection
       end
     end
 
-    desc 'diff', 'Show changes that will be applied by converge'
+    desc 'diff STACK', 'Show changes that will be applied by converge'
     option :verbose, :type => :boolean, :aliases => '--v', :desc => 'Show stack progress'
     option :'very-verbose', :type => :boolean, :aliases => '--vv', :desc => 'Show unchanged stacks'
-    def diff
+    def diff(stack = nil)
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
 
       last_event = nil
 
-      @cloud.diff do |d|
+      @cloud.diff(stack) do |d|
         if d.is_a? Model::Event
           if options[:'very-verbose']
             say_status(*d.to_thor)

--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -49,7 +49,9 @@ module Convection
           sleep rand @cloudfile.splay || 2
 
           difference = stack.diff
-          next block.call(Model::Event.new(:unchanged, "Stack #{ stack.cloud_name } Has no changes", :info)) if difference.empty?
+          if difference.empty?
+            difference << Model::Event.new(:unchanged, "Stack #{ stack.cloud_name } Has no changes", :info)
+          end
 
           difference.each { |diff| block.call(diff) }
         end

--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -43,7 +43,7 @@ module Convection
         end
       end
 
-      def diff(&block)
+      def diff(to_stack, &block)
         @cloudfile.deck.each do |stack|
           block.call(Model::Event.new(:compare, "Compare local state of stack #{ stack.name } (#{ stack.cloud_name }) with remote template", :info))
           sleep rand @cloudfile.splay || 2
@@ -54,6 +54,8 @@ module Convection
           end
 
           difference.each { |diff| block.call(diff) }
+
+          break if !to_stack.nil? && stack.name == to_stack
         end
       end
     end

--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -46,7 +46,6 @@ module Convection
       def diff(to_stack, &block)
         @cloudfile.deck.each do |stack|
           block.call(Model::Event.new(:compare, "Compare local state of stack #{ stack.name } (#{ stack.cloud_name }) with remote template", :info))
-          sleep rand @cloudfile.splay || 2
 
           difference = stack.diff
           if difference.empty?
@@ -56,6 +55,7 @@ module Convection
           difference.each { |diff| block.call(diff) }
 
           break if !to_stack.nil? && stack.name == to_stack
+          sleep rand @cloudfile.splay || 2
         end
       end
     end


### PR DESCRIPTION
This makes the `convection diff` command behave the same way the `convection converge` command does. It takes an optional `STACK` argument, the name of the stack to diff up to. If the stack name's given, the diff will halt at the named stack.