### PR TITLE
Fix #130 - Support after_update/before_update task types

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -40,6 +40,8 @@ Metrics/LineLength:
 # Offense count: 32
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
+  Exclude:
+    - 'lib/convection/control/stack.rb'
   Max: 37
 
 # Offense count: 5

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,6 +23,8 @@ Metrics/AbcSize:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
+  Exclude:
+    - 'lib/convection/control/stack.rb'
   Max: 304
 
 # Offense count: 6

--- a/test/convection/tasks/test_after_update_tasks.rb
+++ b/test/convection/tasks/test_after_update_tasks.rb
@@ -19,12 +19,13 @@ class TestAfterUpdateTasks < Minitest::Test
     Aws::CloudFormation::Client.stub :new, mock_cloudformation_client do
       Aws::EC2::Client.stub :new, mock_ec2_client do
         # when - a stack is initialized with a after_update_task
+        task = CollectAvailabilityZonesTask.new
         stack = ::Convection::Control::Stack.new('EC2 VPC Test Stack', @template) do
-          after_update_task CollectAvailabilityZonesTask.new
+          after_update_task task
         end
 
-        # then - at least one task should be present
-        refute_empty stack.tasks[:after_update]
+        # then - the given stack should be present
+        assert_includes stack.tasks[:after_update], task
       end
     end
   end

--- a/test/convection/tasks/test_after_update_tasks.rb
+++ b/test/convection/tasks/test_after_update_tasks.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+class TestAfterUpdateTasks < Minitest::Test
+  include TestHelper
+
+  def setup
+    @template = ::Convection.template do
+      description 'EC2 VPC Test Template'
+
+      ec2_vpc 'TargetVPC' do
+        network '10.0.0.0'
+        subnet_length 24
+        enable_dns
+      end
+    end
+  end
+
+  def test_after_update_task_is_registered
+    Aws::CloudFormation::Client.stub :new, mock_cloudformation_client do
+      Aws::EC2::Client.stub :new, mock_ec2_client do
+        # when - a stack is initialized with a after_update_task
+        stack = ::Convection::Control::Stack.new('EC2 VPC Test Stack', @template) do
+          after_update_task CollectAvailabilityZonesTask.new
+        end
+
+        # then - at least one task should be present
+        refute_empty stack.tasks[:after_update]
+      end
+    end
+  end
+
+  def test_after_update_task_is_executed
+    Aws::CloudFormation::Client.stub :new, mock_cloudformation_client do
+      Aws::EC2::Client.stub :new, mock_ec2_client do
+        # given - a stack initialized with a after_update_task
+        task = CollectAvailabilityZonesTask.new
+        stack = ::Convection::Control::Stack.new('EC2 VPC Test Stack', @template) do
+          after_update_task task
+        end
+
+        # when - any changes to the stack are applied
+        stub_existence(stack, true) do
+          stack.apply
+        end
+
+        # then - the task should have been executed
+        assert_includes task.availability_zones, 'eu-central-1'
+      end
+    end
+  end
+
+  def test_after_update_task_is_deregistered
+    Aws::CloudFormation::Client.stub :new, mock_cloudformation_client do
+      Aws::EC2::Client.stub :new, mock_ec2_client do
+        # given - a stack initialized with a after_update_task
+        stack = ::Convection::Control::Stack.new('EC2 VPC Test Stack', @template) do
+          after_update_task CollectAvailabilityZonesTask.new
+        end
+
+        # when - any changes to the stack are applied
+        stub_existence(stack, true) do
+          stack.apply
+        end
+
+        # then - the task should have been deregistered
+        assert_empty stack.tasks[:after_update]
+      end
+    end
+  end
+end

--- a/test/convection/tasks/test_before_update_tasks.rb
+++ b/test/convection/tasks/test_before_update_tasks.rb
@@ -19,12 +19,13 @@ class TestBeforeUpdateTasks < Minitest::Test
     Aws::CloudFormation::Client.stub :new, mock_cloudformation_client do
       Aws::EC2::Client.stub :new, mock_ec2_client do
         # when - a stack is initialized with a before_update_task
+        task = CollectAvailabilityZonesTask.new
         stack = ::Convection::Control::Stack.new('EC2 VPC Test Stack', @template) do
-          before_update_task CollectAvailabilityZonesTask.new
+          before_update_task task
         end
 
-        # then - at least one task should be present
-        refute_empty stack.tasks[:before_update]
+        # then - the given stack should be present
+        assert_includes stack.tasks[:before_update], task
       end
     end
   end

--- a/test/convection/tasks/test_before_update_tasks.rb
+++ b/test/convection/tasks/test_before_update_tasks.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+class TestBeforeUpdateTasks < Minitest::Test
+  include TestHelper
+
+  def setup
+    @template = ::Convection.template do
+      description 'EC2 VPC Test Template'
+
+      ec2_vpc 'TargetVPC' do
+        network '10.0.0.0'
+        subnet_length 24
+        enable_dns
+      end
+    end
+  end
+
+  def test_before_update_task_is_registered
+    Aws::CloudFormation::Client.stub :new, mock_cloudformation_client do
+      Aws::EC2::Client.stub :new, mock_ec2_client do
+        # when - a stack is initialized with a before_update_task
+        stack = ::Convection::Control::Stack.new('EC2 VPC Test Stack', @template) do
+          before_update_task CollectAvailabilityZonesTask.new
+        end
+
+        # then - at least one task should be present
+        refute_empty stack.tasks[:before_update]
+      end
+    end
+  end
+
+  def test_before_update_task_is_executed
+    Aws::CloudFormation::Client.stub :new, mock_cloudformation_client do
+      Aws::EC2::Client.stub :new, mock_ec2_client do
+        # given - a stack initialized with a before_update_task
+        task = CollectAvailabilityZonesTask.new
+        stack = ::Convection::Control::Stack.new('EC2 VPC Test Stack', @template) do
+          before_update_task task
+        end
+
+        # when - any changes to the stack are applied
+        stub_existence(stack, true) do
+          stack.apply
+        end
+
+        # then - the task should have been executed
+        assert_includes task.availability_zones, 'eu-central-1'
+      end
+    end
+  end
+
+  def test_before_update_task_is_deregistered
+    Aws::CloudFormation::Client.stub :new, mock_cloudformation_client do
+      Aws::EC2::Client.stub :new, mock_ec2_client do
+        # given - a stack initialized with a before_update_task
+        stack = ::Convection::Control::Stack.new('EC2 VPC Test Stack', @template) do
+          before_update_task CollectAvailabilityZonesTask.new
+        end
+
+        # when - any changes to the stack are applied
+        stub_existence(stack, true) do
+          stack.apply
+        end
+
+        # then - the task should have been deregistered
+        assert_empty stack.tasks[:before_update]
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,6 +41,7 @@ module TestHelper
     cf_client.expect(:create_stack, nil, any_args)
     cf_client.expect(:delete_stack, nil, any_args)
     cf_client.expect(:describe_stacks, nil)
+    cf_client.expect(:update_stack, nil, any_args)
     def cf_client.describe_stacks(*)
       context = nil # we don't need any request context here.
       raise Aws::CloudFormation::Errors::ValidationError.new(context, 'Stack does not exist.')
@@ -60,5 +61,12 @@ module TestHelper
     ec2_client = Minitest::Mock.new
     ec2_client.expect(:describe_availability_zones, availability_zone_description)
     ec2_client
+  end
+
+  # Stub both exist/exist? since aliases are not overridden when stubbing in minitest.
+  def stub_existence(stack, exists, &block)
+    stack.stub(:exist, exists) do
+      stack.stub(:exist?, exists, &block)
+    end
   end
 end


### PR DESCRIPTION
Fix #130:

>- [x] Create a new `before_update` task category
>- [x] Create a new `after_update` task category
>- [x] Run update tasks before/after the update phase
>
>See also https://github.com/rapid7/convection/issues/114 and https://github.com/rapid7/convection/issues/120.