### PR TITLE
Add improvements useful for convection extensions

### DIFF
--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -89,6 +89,15 @@ module Convection
         @current_template = {}
         @last_event_seen = nil
 
+        # First pass evaluation of stack
+        # This is important because it:
+        #   * Catches syntax errors before starting a converge
+        #   * Builds a list of all resources that allows stacks early in
+        #     the dependency tree to know about later stacks.  Some
+        #     clouds use this, for example, to create security groups early
+        #     in the dependency tree to avoid the chicken-and-egg problem.
+        @template.execute
+
         ## Get initial state
         get_status(cloud_name)
         return unless exist?
@@ -379,7 +388,6 @@ module Convection
       ## TODO No. This will become unnecessary as current_state is fleshed out
       def resource_attributes
         @attribute_mapping_values = {}
-        @template.execute ## Populate mappings fro the template
 
         @resources.each do |logical, resource|
           next unless @template.attribute_mappings.include?(logical)

--- a/lib/convection/model/template/resource.rb
+++ b/lib/convection/model/template/resource.rb
@@ -285,6 +285,7 @@ module Convection
         ##
         attribute :type
         attr_reader :name
+        attr_reader :parent
         attr_reader :template
         attr_reader :properties
         attr_reader :resource_attributes
@@ -293,6 +294,7 @@ module Convection
 
         def initialize(name, parent)
           @name = name
+          @parent = parent
           @template = parent.template
           @type = self.class.type
           @depends_on = []


### PR DESCRIPTION
We are extending convection to allow composing multiple CloudFormation resources into custom resources (or "resource groups") that contain custom business logic.  This PR adds a couple of simple improvements that make extending much easier.  These fixes should largely be a no-op for regular convection usage.

* 29d1c233812fa40560550e10103831ccd3e10a72 - Always preform a two-pass compilation of stacks.  The first pass checks for syntax errors and allows stacks with custom resources to compile.  This makes sure we fail fast.  It also allows stacks earlier in the dependency tree to access class variables from stacks later in the dependency tree.  This is useful for solving chicken-and-egg problems like ensuring we create security groups before attaching them in other stacks.  Our experiments show this adds almost no time to converges/diffs/etc.
* b82aa47d633d568ceae75d42e9ad3af277852eb7 - Provide a `parent` reference within resources.  This allows accessing the parent scope (usually a convection template, but sometimes a custom resource) from within a resource.  In the DSL, this is useful to access parent methods from inside a resource.