### PR TITLE
Fix a typo in the aws_s3_bucket.rb resource

### DIFF
--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -13,7 +13,7 @@ module Convection
           type 'AWS::S3::Bucket'
           property :bucket_name, 'BucketName'
           property :access_control, 'AccessControl'
-          property :cors_configurationm, 'CorsConfiguration'
+          property :cors_configuration, 'CorsConfiguration'
           property :lifecycle_configuration, 'LifecycleConfiguration'
           property :logging_configuration, 'LoggingConfiguration'
           property :notification_configuration, 'NotificationConfiguration'

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -19,6 +19,11 @@ module Convection
           property :notification_configuration, 'NotificationConfiguration'
           property :versioning_configuration, 'VersioningConfiguration'
 
+          def cors_configurationm(*args)
+            warn 'DEPRECATED: "cors_configurationm" is deprecated. Please use "cors_configuration" instead. https://github.com/rapid7/convection/pull/135'
+            cors_configuration(*args)
+          end
+
           def render(*args)
             super.tap do |resource|
               render_tags(resource)


### PR DESCRIPTION
See also https://github.com/rapid7/convection/commit/782208968f#diff-7126ecd8a0f873d6bdeffcaf269fb9a7R15 where this typo was introduced.

cc @jmanero-r7 @athompson-r7 @simonirwin-r7 @abegley-r7 