### PR TITLE
Fix #141 - Define the managed_policy_arn property for the iam_user resource

### DIFF
--- a/lib/convection/model/template/resource/aws_iam_user.rb
+++ b/lib/convection/model/template/resource/aws_iam_user.rb
@@ -46,6 +46,8 @@ module Convection
           property :login_profile, 'LoginProfile'
           property :group, 'Groups', :type => :list
           property :policies, 'Policies', :type => :list
+          property :managed_policy_arn, 'ManagedPolicyArns', :type => :list
+          alias managed_policy managed_policy_arn
         end
       end
     end


### PR DESCRIPTION
See also #141.

Same as in `aws_iam_role`.