### PR TITLE
Support s3 configuration as first class citizens

### DIFF
--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -23,7 +23,8 @@ module Convection
             config = ResourceProperty::S3CorsConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining cors_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
+            warn 'DEPRECATED: Defining cors_configuration with an options Hash is deprecated. ' \
+              'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3CorsConfiguration.properties.each do |_name, property|
               property_name = property.property_name
               config.properties[property_name] = opts[property_name] if opts.key?(property_name)
@@ -42,7 +43,8 @@ module Convection
             config = ResourceProperty::S3LifecycleConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining lifecycle_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
+            warn 'DEPRECATED: Defining lifecycle_configuration with an options Hash is deprecated. ' \
+              'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3LifecycleConfiguration.properties.each do |_name, property|
               property_name = property.property_name
               config.properties[property_name] = opts[property_name] if opts.key?(property_name)
@@ -56,7 +58,8 @@ module Convection
             config = ResourceProperty::S3LoggingConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining logging_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
+            warn 'DEPRECATED: Defining logging_configuration with an options Hash is deprecated. ' \
+              'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3LoggingConfiguration.properties.each do |_name, property|
               property_name = property.property_name
               config.properties[property_name] = opts[property_name] if opts.key?(property_name)
@@ -70,7 +73,8 @@ module Convection
             config = ResourceProperty::S3NotificationConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining notification_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
+            warn 'DEPRECATED: Defining notification_configuration with an options Hash is deprecated. ' \
+              'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3NotificationConfiguration.properties.each do |_name, property|
               property_name = property.property_name
               config.properties[property_name] = opts[property_name] if opts.key?(property_name)
@@ -84,7 +88,8 @@ module Convection
             config = ResourceProperty::S3ReplicationConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining replication_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
+            warn 'DEPRECATED: Defining replication_configuration with an options Hash is deprecated. ' \
+              'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3ReplicationConfiguration.properties.each do |_name, property|
               property_name = property.property_name
               config.properties[property_name] = opts[property_name] if opts.key?(property_name)
@@ -98,7 +103,8 @@ module Convection
             config = ResourceProperty::S3VersioningConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining versioning_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
+            warn 'DEPRECATED: Defining versioning_configuration with an options Hash is deprecated. ' \
+              'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3VersioningConfiguration.properties.each do |_name, property|
               property_name = property.property_name
               config.properties[property_name] = opts[property_name] if opts.key?(property_name)
@@ -112,7 +118,8 @@ module Convection
             config = ResourceProperty::S3WebsiteConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining website_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
+            warn 'DEPRECATED: Defining website_configuration with an options Hash is deprecated. ' \
+              'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3WebsiteConfiguration.properties.each do |_name, property|
               property_name = property.property_name
               config.properties[property_name] = opts[property_name] if opts.key?(property_name)

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -43,6 +43,19 @@ module Convection
             properties['LifecycleConfiguration'].set(config)
           end
 
+          def logging_configuration(opts = {}, &block)
+            config = ResourceProperty::S3LoggingConfiguration.new(self)
+
+            # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
+            warn 'DEPRECATED: Defining logging_configuration with an options Hash is deprecated. Please use a configuration block instead.'
+            ResourceProperty::S3LoggingConfiguration.properties.each do |_name, property|
+              config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
+            end
+
+            config.instance_exec(&block) if block
+            properties['LoggingConfiguration'].set(config)
+          end
+
           def render(*args)
             super.tap do |resource|
               render_tags(resource)

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -56,6 +56,19 @@ module Convection
             properties['LoggingConfiguration'].set(config)
           end
 
+          def notification_configuration(&block)
+            config = ResourceProperty::S3NotificationConfiguration.new(self)
+
+            # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
+            warn 'DEPRECATED: Defining notification_configuration with an options Hash is deprecated. Please use a configuration block instead.'
+            ResourceProperty::S3NotificationConfiguration.properties.each do |_name, property|
+              config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
+            end
+
+            config.instance_exec(&block) if block
+            properties['NotificationConfiguration'].set(config)
+          end
+
           def render(*args)
             super.tap do |resource|
               render_tags(resource)

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -19,8 +19,15 @@ module Convection
           property :notification_configuration, 'NotificationConfiguration'
           property :versioning_configuration, 'VersioningConfiguration'
 
-          def cors_configuration(&block)
+          def cors_configuration(opts = {}, &block)
             config = ResourceProperty::S3CorsConfiguration.new(self)
+
+            # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
+            warn 'DEPRECATED: Defining cors_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
+            ResourceProperty::S3CorsConfiguration.properties.each do |_name, property|
+              config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
+            end
+
             config.instance_exec(&block) if block
             properties['CorsConfiguration'].set(config)
           end

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -17,7 +17,9 @@ module Convection
           property :lifecycle_configuration, 'LifecycleConfiguration'
           property :logging_configuration, 'LoggingConfiguration'
           property :notification_configuration, 'NotificationConfiguration'
+          property :replication_configuration, 'ReplicationConfiguration'
           property :versioning_configuration, 'VersioningConfiguration'
+          property :website_configuration, 'WebsiteConfiguration'
 
           def cors_configuration(opts = {}, &block)
             config = ResourceProperty::S3CorsConfiguration.new(self)
@@ -84,17 +86,8 @@ module Convection
             properties['NotificationConfiguration'].set(config)
           end
 
-          def replication_configuration(opts = {}, &block)
+          def replication_configuration(&block)
             config = ResourceProperty::S3ReplicationConfiguration.new(self)
-
-            # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining replication_configuration with an options Hash is deprecated. ' \
-              'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
-            ResourceProperty::S3ReplicationConfiguration.properties.each do |_name, property|
-              property_name = property.property_name
-              config.property property_name, opts[property_name] if opts.key?(property_name)
-            end
-
             config.instance_exec(&block) if block
             properties['ReplicationConfiguration'].set(config)
           end
@@ -114,17 +107,8 @@ module Convection
             properties['VersioningConfiguration'].set(config)
           end
 
-          def website_configuration(opts = {}, &block)
+          def website_configuration(&block)
             config = ResourceProperty::S3WebsiteConfiguration.new(self)
-
-            # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining website_configuration with an options Hash is deprecated. ' \
-              'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
-            ResourceProperty::S3WebsiteConfiguration.properties.each do |_name, property|
-              property_name = property.property_name
-              config.property property_name, opts[property_name] if opts.key?(property_name)
-            end
-
             config.instance_exec(&block) if block
             properties['WebsiteConfiguration'].set(config)
           end

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -95,6 +95,19 @@ module Convection
             properties['VersioningConfiguration'].set(config)
           end
 
+          def website_configuration(&block)
+            config = ResourceProperty::S3WebsiteConfiguration.new(self)
+
+            # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
+            warn 'DEPRECATED: Defining website_configuration with an options Hash is deprecated. Please use a configuration block instead.'
+            ResourceProperty::S3WebsiteConfiguration.properties.each do |_name, property|
+              config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
+            end
+
+            config.instance_exec(&block) if block
+            properties['WebsiteConfiguration'].set(config)
+          end
+
           def render(*args)
             super.tap do |resource|
               render_tags(resource)

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -30,6 +30,19 @@ module Convection
             cors_configuration(*args)
           end
 
+          def lifecycle_configuration(opts = {}, &block)
+            config = ResourceProperty::S3LifecycleConfiguration.new(self)
+
+            # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
+            warn 'DEPRECATED: Defining lifecycle_configuration with an options Hash is deprecated. Please use a configuration block instead.'
+            ResourceProperty::S3LifecycleConfiguration.properties.each do |_name, property|
+              config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
+            end
+
+            config.instance_exec(&block) if block
+            properties['LifecycleConfiguration'].set(config)
+          end
+
           def render(*args)
             super.tap do |resource|
               render_tags(resource)

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -56,7 +56,7 @@ module Convection
             properties['LoggingConfiguration'].set(config)
           end
 
-          def notification_configuration(&block)
+          def notification_configuration(opts = {}, &block)
             config = ResourceProperty::S3NotificationConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
@@ -69,7 +69,7 @@ module Convection
             properties['NotificationConfiguration'].set(config)
           end
 
-          def replication_configuration(&block)
+          def replication_configuration(opts = {}, &block)
             config = ResourceProperty::S3ReplicationConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
@@ -82,7 +82,7 @@ module Convection
             properties['ReplicationConfiguration'].set(config)
           end
 
-          def versioning_configuration(&block)
+          def versioning_configuration(opts = {}, &block)
             config = ResourceProperty::S3VersioningConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
@@ -95,7 +95,7 @@ module Convection
             properties['VersioningConfiguration'].set(config)
           end
 
-          def website_configuration(&block)
+          def website_configuration(opts = {}, &block)
             config = ResourceProperty::S3WebsiteConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -27,7 +27,7 @@ module Convection
               'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3CorsConfiguration.properties.each do |_name, property|
               property_name = property.property_name
-              config.properties[property_name] = opts[property_name] if opts.key?(property_name)
+              config.property property_name, opts[property_name] if opts.key?(property_name)
             end
 
             config.instance_exec(&block) if block
@@ -47,7 +47,7 @@ module Convection
               'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3LifecycleConfiguration.properties.each do |_name, property|
               property_name = property.property_name
-              config.properties[property_name] = opts[property_name] if opts.key?(property_name)
+              config.property property_name, opts[property_name] if opts.key?(property_name)
             end
 
             config.instance_exec(&block) if block
@@ -62,7 +62,7 @@ module Convection
               'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3LoggingConfiguration.properties.each do |_name, property|
               property_name = property.property_name
-              config.properties[property_name] = opts[property_name] if opts.key?(property_name)
+              config.property property_name, opts[property_name] if opts.key?(property_name)
             end
 
             config.instance_exec(&block) if block
@@ -77,7 +77,7 @@ module Convection
               'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3NotificationConfiguration.properties.each do |_name, property|
               property_name = property.property_name
-              config.properties[property_name] = opts[property_name] if opts.key?(property_name)
+              config.property property_name, opts[property_name] if opts.key?(property_name)
             end
 
             config.instance_exec(&block) if block
@@ -92,7 +92,7 @@ module Convection
               'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3ReplicationConfiguration.properties.each do |_name, property|
               property_name = property.property_name
-              config.properties[property_name] = opts[property_name] if opts.key?(property_name)
+              config.property property_name, opts[property_name] if opts.key?(property_name)
             end
 
             config.instance_exec(&block) if block
@@ -107,7 +107,7 @@ module Convection
               'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3VersioningConfiguration.properties.each do |_name, property|
               property_name = property.property_name
-              config.properties[property_name] = opts[property_name] if opts.key?(property_name)
+              config.property property_name, opts[property_name] if opts.key?(property_name)
             end
 
             config.instance_exec(&block) if block
@@ -122,7 +122,7 @@ module Convection
               'Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3WebsiteConfiguration.properties.each do |_name, property|
               property_name = property.property_name
-              config.properties[property_name] = opts[property_name] if opts.key?(property_name)
+              config.property property_name, opts[property_name] if opts.key?(property_name)
             end
 
             config.instance_exec(&block) if block

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -69,6 +69,19 @@ module Convection
             properties['NotificationConfiguration'].set(config)
           end
 
+          def replication_configuration(&block)
+            config = ResourceProperty::S3ReplicationConfiguration.new(self)
+
+            # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
+            warn 'DEPRECATED: Defining replication_configuration with an options Hash is deprecated. Please use a configuration block instead.'
+            ResourceProperty::S3ReplicationConfiguration.properties.each do |_name, property|
+              config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
+            end
+
+            config.instance_exec(&block) if block
+            properties['ReplicationConfiguration'].set(config)
+          end
+
           def render(*args)
             super.tap do |resource|
               render_tags(resource)

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -82,6 +82,19 @@ module Convection
             properties['ReplicationConfiguration'].set(config)
           end
 
+          def versioning_configuration(&block)
+            config = ResourceProperty::S3VersioningConfiguration.new(self)
+
+            # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
+            warn 'DEPRECATED: Defining versioning_configuration with an options Hash is deprecated. Please use a configuration block instead.'
+            ResourceProperty::S3VersioningConfiguration.properties.each do |_name, property|
+              config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
+            end
+
+            config.instance_exec(&block) if block
+            properties['VersioningConfiguration'].set(config)
+          end
+
           def render(*args)
             super.tap do |resource|
               render_tags(resource)

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -25,7 +25,8 @@ module Convection
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
             warn 'DEPRECATED: Defining cors_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3CorsConfiguration.properties.each do |_name, property|
-              config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
+              property_name = property.property_name
+              config.properties[property_name] = opts[property_name] if opts.key?(property_name)
             end
 
             config.instance_exec(&block) if block
@@ -43,7 +44,8 @@ module Convection
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
             warn 'DEPRECATED: Defining lifecycle_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3LifecycleConfiguration.properties.each do |_name, property|
-              config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
+              property_name = property.property_name
+              config.properties[property_name] = opts[property_name] if opts.key?(property_name)
             end
 
             config.instance_exec(&block) if block
@@ -56,7 +58,8 @@ module Convection
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
             warn 'DEPRECATED: Defining logging_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3LoggingConfiguration.properties.each do |_name, property|
-              config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
+              property_name = property.property_name
+              config.properties[property_name] = opts[property_name] if opts.key?(property_name)
             end
 
             config.instance_exec(&block) if block
@@ -69,7 +72,8 @@ module Convection
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
             warn 'DEPRECATED: Defining notification_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3NotificationConfiguration.properties.each do |_name, property|
-              config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
+              property_name = property.property_name
+              config.properties[property_name] = opts[property_name] if opts.key?(property_name)
             end
 
             config.instance_exec(&block) if block
@@ -82,7 +86,8 @@ module Convection
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
             warn 'DEPRECATED: Defining replication_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3ReplicationConfiguration.properties.each do |_name, property|
-              config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
+              property_name = property.property_name
+              config.properties[property_name] = opts[property_name] if opts.key?(property_name)
             end
 
             config.instance_exec(&block) if block
@@ -95,7 +100,8 @@ module Convection
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
             warn 'DEPRECATED: Defining versioning_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3VersioningConfiguration.properties.each do |_name, property|
-              config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
+              property_name = property.property_name
+              config.properties[property_name] = opts[property_name] if opts.key?(property_name)
             end
 
             config.instance_exec(&block) if block
@@ -108,7 +114,8 @@ module Convection
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
             warn 'DEPRECATED: Defining website_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3WebsiteConfiguration.properties.each do |_name, property|
-              config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
+              property_name = property.property_name
+              config.properties[property_name] = opts[property_name] if opts.key?(property_name)
             end
 
             config.instance_exec(&block) if block

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -34,7 +34,7 @@ module Convection
             config = ResourceProperty::S3LifecycleConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining lifecycle_configuration with an options Hash is deprecated. Please use a configuration block instead.'
+            warn 'DEPRECATED: Defining lifecycle_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143'
             ResourceProperty::S3LifecycleConfiguration.properties.each do |_name, property|
               config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
             end
@@ -47,7 +47,7 @@ module Convection
             config = ResourceProperty::S3LoggingConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining logging_configuration with an options Hash is deprecated. Please use a configuration block instead.'
+            warn 'DEPRECATED: Defining logging_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143'
             ResourceProperty::S3LoggingConfiguration.properties.each do |_name, property|
               config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
             end
@@ -60,7 +60,7 @@ module Convection
             config = ResourceProperty::S3NotificationConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining notification_configuration with an options Hash is deprecated. Please use a configuration block instead.'
+            warn 'DEPRECATED: Defining notification_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143'
             ResourceProperty::S3NotificationConfiguration.properties.each do |_name, property|
               config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
             end
@@ -73,7 +73,7 @@ module Convection
             config = ResourceProperty::S3ReplicationConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining replication_configuration with an options Hash is deprecated. Please use a configuration block instead.'
+            warn 'DEPRECATED: Defining replication_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143'
             ResourceProperty::S3ReplicationConfiguration.properties.each do |_name, property|
               config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
             end
@@ -86,7 +86,7 @@ module Convection
             config = ResourceProperty::S3VersioningConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining versioning_configuration with an options Hash is deprecated. Please use a configuration block instead.'
+            warn 'DEPRECATED: Defining versioning_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143'
             ResourceProperty::S3VersioningConfiguration.properties.each do |_name, property|
               config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
             end
@@ -99,7 +99,7 @@ module Convection
             config = ResourceProperty::S3WebsiteConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining website_configuration with an options Hash is deprecated. Please use a configuration block instead.'
+            warn 'DEPRECATED: Defining website_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143'
             ResourceProperty::S3WebsiteConfiguration.properties.each do |_name, property|
               config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
             end

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -34,7 +34,7 @@ module Convection
             config = ResourceProperty::S3LifecycleConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining lifecycle_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143'
+            warn 'DEPRECATED: Defining lifecycle_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3LifecycleConfiguration.properties.each do |_name, property|
               config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
             end
@@ -47,7 +47,7 @@ module Convection
             config = ResourceProperty::S3LoggingConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining logging_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143'
+            warn 'DEPRECATED: Defining logging_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3LoggingConfiguration.properties.each do |_name, property|
               config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
             end
@@ -60,7 +60,7 @@ module Convection
             config = ResourceProperty::S3NotificationConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining notification_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143'
+            warn 'DEPRECATED: Defining notification_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3NotificationConfiguration.properties.each do |_name, property|
               config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
             end
@@ -73,7 +73,7 @@ module Convection
             config = ResourceProperty::S3ReplicationConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining replication_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143'
+            warn 'DEPRECATED: Defining replication_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3ReplicationConfiguration.properties.each do |_name, property|
               config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
             end
@@ -86,7 +86,7 @@ module Convection
             config = ResourceProperty::S3VersioningConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining versioning_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143'
+            warn 'DEPRECATED: Defining versioning_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3VersioningConfiguration.properties.each do |_name, property|
               config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
             end
@@ -99,7 +99,7 @@ module Convection
             config = ResourceProperty::S3WebsiteConfiguration.new(self)
 
             # TODO: Remove this deprecation and remove the opts declaration/usage hash above/below.
-            warn 'DEPRECATED: Defining website_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143'
+            warn 'DEPRECATED: Defining website_configuration with an options Hash is deprecated. Please use a configuration block instead. https://github.com/rapid7/convection/pull/143' if opts && opts.any?
             ResourceProperty::S3WebsiteConfiguration.properties.each do |_name, property|
               config.properties[property.property_name] = opts[property_name] if opts.key?(property_name)
             end

--- a/lib/convection/model/template/resource_property/aws_s3_lambda_notification_configuration.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_lambda_notification_configuration.rb
@@ -1,0 +1,23 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-lambdaconfig.html
+        # Amazon S3 NotificationConfiguration LambdaConfiguration}
+        class S3LambdaNotificationConfiguration < ResourceProperty
+          property :event, 'Event'
+          property :filter, 'Filter'
+          property :function, 'Function'
+
+          def filter(&block)
+            filter = ResourceProperty::S3NotificationConfigurationFilter.new(self)
+            filter.instance_exec(&block) if block
+            properties['Filter'].set(filter)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_lifecycle_configuration.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_lifecycle_configuration.rb
@@ -1,0 +1,21 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-lifecycleconfig.html
+        # Amazon S3 Lifecycle Configuration}
+        class S3LifecycleConfiguration < ResourceProperty
+          property :rules, 'Rules', :type => :list
+
+          def rule(&block)
+            rule = ResourceProperty::S3LifecycleConfigurationRule.new(self)
+            rule.instance_exec(&block) if block
+            rules << rule
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_lifecycle_configuration_rule.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_lifecycle_configuration_rule.rb
@@ -1,0 +1,34 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-lifecycleconfig-rule.html
+        # Amazon S3 Lifecycle Rule}
+        class S3LifecycleConfigurationRule < ResourceProperty
+          property :expiration_date, 'ExpirationDate'
+          property :expiration_in_days, 'ExpirationInDays'
+          property :id, 'Id'
+          property :noncurrent_version_expiration_in_days, 'NoncurrentVersionExpirationInDays'
+          property :noncurrent_version_transitions, 'NoncurrentVersionTransitions', :type => :list
+          property :prefix, 'Prefix'
+          property :status, 'Status'
+          property :transitions, 'Transitions', :type => :list
+
+          def transition(&block)
+            transition = ResourceProperty::S3LifecycleRuleTransition.new(self)
+            transition.instance_exec(&block) if block
+            transitions << transition
+          end
+
+          def noncurrent_version_transition(&block)
+            noncurrent_version_transition = ResourceProperty::S3LifecycleRuleNoncurrentVersionTransition.new(self)
+            noncurrent_version_transition.instance_exec(&block) if block
+            noncurrent_version_transitions << noncurrent_version_transition
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_lifecycle_rule_noncurrent_version_transition.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_lifecycle_rule_noncurrent_version_transition.rb
@@ -1,0 +1,16 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-lifecycleconfig-rule-noncurrentversiontransition.html
+        # Amazon S3 Lifecycle Rule NoncurrentVersionTransition}
+        class S3LifecycleRuleNoncurrentVersionTransition < ResourceProperty
+          property :storage_class, 'StorageClass'
+          property :transition_in_days, 'TransitionInDays'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_lifecycle_rule_transition.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_lifecycle_rule_transition.rb
@@ -1,0 +1,17 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-lifecycleconfig-rule-transition.html
+        # Amazon S3 Lifecycle Rule Transition}
+        class S3LifecycleRuleTransition < ResourceProperty
+          property :storage_class, 'StorageClass'
+          property :transition_date, 'TransitionDate'
+          property :transition_in_days, 'TransitionInDays'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_logging_configuration.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_logging_configuration.rb
@@ -1,0 +1,16 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-loggingconfig.html
+        # Amazon S3 Logging Configuration}
+        class S3LoggingConfiguration < ResourceProperty
+          property :destination_bucket_name, 'DestinationBucketName'
+          property :log_file_prefix, 'LogFilePrefix'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_notification_configuration.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_notification_configuration.rb
@@ -1,0 +1,35 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig.html
+        # Amazon S3 Notification Configuration}
+        class S3NotificationConfiguration < ResourceProperty
+          property :lambda_configurations, 'LambdaConfigurations', :type => :list
+          property :queue_configurations, 'QueueConfigurations', :type => :list
+          property :topic_configurations, 'TopicConfigurations', :type => :list
+
+          def lambda_configuration(&block)
+            lambda_configuration = ResourceProperty::S3LambdaNotificationConfiguration.new(self)
+            lambda_configuration.instance_exec(&block) if block
+            lambda_configurations << lambda_configuration
+          end
+
+          def queue_configuration(&block)
+            queue_configuration = ResourceProperty::S3QueueNotificationConfiguration.new(self)
+            queue_configuration.instance_exec(&block) if block
+            queue_configurations << queue_configuration
+          end
+
+          def topic_configuration(&block)
+            topic_configuration = ResourceProperty::S3TopicNotificationConfiguration.new(self)
+            topic_configuration.instance_exec(&block) if block
+            topic_configurations << topic_configuration
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_notification_configuration_filter.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_notification_configuration_filter.rb
@@ -1,0 +1,21 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfiguration-config-filter.html
+        # Amazon S3 NotificationConfiguration Config Filter}
+        class S3NotificationConfigurationFilter < ResourceProperty
+          property :s3_key, 'S3Key'
+
+          def s3_key(&block)
+            s3_key = ResourceProperty::S3NotificationConfigurationFilterS3Key.new(self)
+            s3_key.instance_exec(&block) if block
+            properties['S3Key'].set(s3_key)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_notification_configuration_filter_s3_key.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_notification_configuration_filter_s3_key.rb
@@ -1,0 +1,21 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfiguration-config-filter-s3key.html
+        # Amazon S3 NotificationConfiguration Config Filter S3Key}
+        class S3NotificationConfigurationFilterS3Key < ResourceProperty
+          property :rules, 'Rules', :type => :list
+
+          def rule(&block)
+            rule = ResourceProperty::S3NotificationConfigurationFilterS3KeyRule.new(self)
+            rule.instance_exec(&block) if block
+            rules << rule
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_notification_configuration_filter_s3_key_rule.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_notification_configuration_filter_s3_key_rule.rb
@@ -1,0 +1,16 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfiguration-config-filter-s3key-rules.html
+        # Amazon S3 NotificationConfiguration Config Filter S3Key Rules}
+        class S3NotificationConfigurationFilterS3KeyRule < ResourceProperty
+          property :name, 'Name'
+          property :value, 'Value'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_queue_notification_configuration.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_queue_notification_configuration.rb
@@ -1,0 +1,23 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-queueconfig.html
+        # Amazon S3 NotificationConfiguration QueueConfiguration}
+        class S3QueueNotificationConfiguration < ResourceProperty
+          property :event, 'Event'
+          property :filter, 'Filter'
+          property :queue, 'Queue'
+
+          def filter(&block)
+            filter = ResourceProperty::S3NotificationConfigurationFilter.new(self)
+            filter.instance_exec(&block) if block
+            properties['Filter'].set(filter)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_replication_configuration.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_replication_configuration.rb
@@ -1,0 +1,22 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration.html
+        # Amazon S3 Replication Configuration}
+        class S3ReplicationConfiguration < ResourceProperty
+          property :role, 'Role'
+          property :rules, 'Rules', :type => :list
+
+          def rule(&block)
+            rule = ResourceProperty::S3ReplicationConfigurationRule.new(self)
+            rule.instance_exec(&block) if block
+            rules << rule
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_replication_configuration_rule.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_replication_configuration_rule.rb
@@ -1,0 +1,24 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration-rules.html
+        # Amazon S3 Replication Configuration Rule}
+        class S3ReplicationConfigurationRule < ResourceProperty
+          property :destination, 'Destination'
+          property :id, 'Id'
+          property :prefix, 'Prefix'
+          property :status, 'Status'
+
+          def destination(&block)
+            destination = ResourceProperty::S3ReplicationConfigurationRuleDestination.new(self)
+            destination.instance_exec(&block) if block
+            properties['Destination'].set(destination)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_replication_configuration_rule_destination.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_replication_configuration_rule_destination.rb
@@ -1,0 +1,16 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration-rules-destination.html
+        # Amazon S3 Replication Configuration Rule Destination}
+        class S3ReplicationConfigurationRuleDestination < ResourceProperty
+          property :bucket, 'Bucket'
+          property :storage_class, 'StorageClass'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_topic_notification_configuration.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_topic_notification_configuration.rb
@@ -1,0 +1,23 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html
+        # Amazon S3 NotificationConfiguration TopicConfiguration}
+        class S3TopicNotificationConfiguration < ResourceProperty
+          property :event, 'Event'
+          property :filter, 'Filter'
+          property :topic, 'Topic'
+
+          def filter(&block)
+            filter = ResourceProperty::S3NotificationConfigurationFilter.new(self)
+            filter.instance_exec(&block) if block
+            properties['Filter'].set(filter)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_versioning_configuration.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_versioning_configuration.rb
@@ -1,0 +1,15 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-versioningconfig.html
+        # Amazon S3 Versioning Configuration}
+        class S3VersioningConfiguration < ResourceProperty
+          property :status, 'Status'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_website_configuration.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_website_configuration.rb
@@ -1,0 +1,30 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-website.html
+        # Amazon S3 Website Configuration}
+        class S3WebsiteConfiguration < ResourceProperty
+          property :error_document, 'ErrorDocument'
+          property :index_document, 'IndexDocument'
+          property :redirect_all_requests_to, 'RedirectAllRequestsTo'
+          property :routing_rules, 'RoutingRules', :type => :list
+
+          def redirect_all_requests_to(&block)
+            redirect_destination = ResourceProperty::S3WebsiteConfigurationRedirectAllRequestsTo.new(self)
+            redirect_destination.instance_exec(&block) if block
+            properties['RedirectAllRequestsTo'].set(redirect_destination)
+          end
+
+          def routing_rule(&block)
+            routing_rule = ResourceProperty::S3WebsiteConfigurationRoutingRule.new(self)
+            routing_rule.instance_exec(&block) if block
+            routing_rules << routing_rule
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_website_configuration_redirect_all_requests_to.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_website_configuration_redirect_all_requests_to.rb
@@ -1,0 +1,16 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html
+        # Amazon S3 Website Configuration Redirect All Requests To Property}
+        class S3WebsiteConfigurationRedirectAllRequestsTo < ResourceProperty
+          property :host_name, 'HostName'
+          property :protocol, 'Protocol'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_website_configuration_redirect_rule.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_website_configuration_redirect_rule.rb
@@ -1,0 +1,19 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules-redirectrule.html
+        # Amazon S3 Website Configuration Routing Rule Redirect Rule}
+        class S3WebsiteConfigurationRedirectRule < ResourceProperty
+          property :host_name, 'HostName'
+          property :http_redirect_code, 'HttpRedirectCode'
+          property :protocol, 'Protocol'
+          property :replace_key_prefix_with, 'ReplaceKeyPrefixWith'
+          property :replace_key_with, 'ReplaceKeyWith'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_website_configuration_routing_rule.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_website_configuration_routing_rule.rb
@@ -1,0 +1,28 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html
+        # Amazon S3 Website Configuration Routing Rule}
+        class S3WebsiteConfigurationRoutingRule < ResourceProperty
+          property :redirect_rule, 'RedirectRule'
+          property :routing_rule_condition, 'RoutingRuleCondition'
+
+          def redirect_rule(&block)
+            rule = ResourceProperty::S3WebsiteConfigurationRedirectRule.new(self)
+            rule.instance_exec(&block) if block
+            properties['RedirectRule'].set(rule)
+          end
+
+          def routing_rule_condition(&block)
+            condition = ResourceProperty::S3WebsiteConfigurationRoutingRuleCondition.new(self)
+            condition.instance_exec(&block) if block
+            properties['RoutingRuleCondition'].set(condition)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_website_configuration_routing_rule_condition.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_website_configuration_routing_rule_condition.rb
@@ -1,0 +1,16 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules-routingrulecondition.html
+        # Amazon S3 Website Configuration Routing Rule Condition}
+        class S3WebsiteConfigurationRoutingRuleCondition < ResourceProperty
+          property :http_error_code_returned_equals, 'HttpErrorCodeReturnedEquals'
+          property :key_prefix_equals, 'KeyPrefixEquals'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rebases #137 from master.

> In #136 I added convection support for `CorsConfiguration` S3 bucket property. This PR takes it one step further by adding all other configuration resource types to convection.
>
* [Lifecycle Configuration](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-lifecycleconfig.html)
* [Logging Configuration](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-loggingconfig.html)
* [Notification Configuration](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig.html)
* [Replication Configuration](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration.html)
* [Versioning Configuration](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-versioningconfig.html)
* [Website Configuration](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-website.html)