### PR TITLE
Fix #146 - Emit events around lifecycle tasks

### DIFF
--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -52,7 +52,7 @@ module Convection
 
       ## Internal status
       NOT_CREATED = 'NOT_CREATED'.freeze
-      TASK_COMPLETED = 'TASK_COMPLETED'.freeze
+      TASK_COMPLETE = 'TASK_COMPLETE'.freeze
       TASK_FAILED = 'TASK_FAILED'.freeze
       TASK_IN_PROGRESS = 'TASK_IN_PROGRESS'.freeze
 
@@ -427,16 +427,16 @@ module Convection
 
       def run_task(phase, task, &block)
         phase = phase.to_s.split.join(' ')
-        block.call(Model::Event.new(TASK_IN_PROGRESS, "Task #{phase} #{task} in progress for stack #{name}.", :info)) if block
+        block.call(Model::Event.new(TASK_IN_PROGRESS, "Task (#{phase}) #{task} in progress for stack #{name}.", :info)) if block
 
         task.call(self)
         return task.success? unless block
 
         if task.success?
-          block.call(Model::Event.new(TASK_COMPLETED, "Task #{phase} #{task} successfully completed for stack #{name}.", :info))
+          block.call(Model::Event.new(TASK_COMPLETE, "Task (#{phase}) #{task} successfully completed for stack #{name}.", :info))
           true
         else
-          block.call(Model::Event.new(TASK_FAILED, "Task #{phase} #{task} failed to complete for stack #{name}.", :error))
+          block.call(Model::Event.new(TASK_FAILED, "Task (#{phase}) #{task} failed to complete for stack #{name}.", :error))
           false
         end
       end

--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -237,7 +237,7 @@ module Convection
       end
 
       def delete(&block)
-        ## execute before delete tasks
+        ## Execute before delete tasks
         @tasks[:before_delete].delete_if do |task|
           run_task(:before_delete, task, &block)
         end

--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -208,6 +208,7 @@ module Convection
             else
               block.call(Model::Event.new(TASK_FAILED, "Task #{task} failed to complete for stack #{name}.", :error)) if block
             end
+            task.success?
           end
 
           ## Update
@@ -224,6 +225,7 @@ module Convection
             else
               block.call(Model::Event.new(TASK_FAILED, "Task #{task} failed to complete for stack #{name}.", :info)) if block
             end
+            task.success?
           end
 
           ## Create
@@ -249,6 +251,7 @@ module Convection
           else
             block.call(Model::Event.new(TASK_FAILED, "Task #{task} failed to complete for stack #{name}.", :info)) if block
           end
+          task.success?
         end
       rescue Aws::Errors::ServiceError => e
         @errors << e
@@ -264,6 +267,7 @@ module Convection
           else
             block.call(Model::Event.new(TASK_FAILED, "Task #{task} failed to complete for stack #{name}.", :info)) if block
           end
+          task.success?
         end
 
         @cf_client.delete_stack(
@@ -284,6 +288,7 @@ module Convection
           else
             block.call(Model::Event.new(TASK_FAILED, "Task #{task} failed to complete for stack #{name}.", :info)) if block
           end
+          task.success?
         end
       rescue Aws::Errors::ServiceError => e
         @errors << e

--- a/lib/convection/model/event.rb
+++ b/lib/convection/model/event.rb
@@ -14,11 +14,12 @@ module Convection
       attr_accessor :level
       attr_accessor :timestamp
       colorize :level,
-               :green => [:info, :success, Control::Stack::CREATE_COMPLETE, Control::Stack::UPDATE_COMPLETE, Control::Stack::UPDATE_ROLLBACK_COMPLETE],
+               :green => [:info, :success, Control::Stack::CREATE_COMPLETE, Control::Stack::UPDATE_COMPLETE, Control::Stack::UPDATE_ROLLBACK_COMPLETE, Control::Stack::TASK_COMPLETED],
                :red => [:error, :fail, Control::Stack::CREATE_FAILED, Control::Stack::ROLLBACK_FAILED,
                         Control::Stack::DELETE_FAILED, Control::Stack::UPDATE_FAILED,
                         Control::Stack::UPDATE_ROLLBACK_IN_PROGRESS, Control::Stack::UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS,
-                        Control::Stack::UPDATE_ROLLBACK_FAILED],
+                        Control::Stack::UPDATE_ROLLBACK_FAILED, Control::Stack::TASK_FAILED],
+               :blue => [Control::Stack::TASK_IN_PROGRESS],
                :default => :yellow
 
       class << self

--- a/lib/convection/model/event.rb
+++ b/lib/convection/model/event.rb
@@ -20,7 +20,6 @@ module Convection
                         Control::Stack::DELETE_FAILED, Control::Stack::UPDATE_FAILED,
                         Control::Stack::UPDATE_ROLLBACK_IN_PROGRESS, Control::Stack::UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS,
                         Control::Stack::UPDATE_ROLLBACK_FAILED, Control::Stack::TASK_FAILED],
-               :blue => [Control::Stack::TASK_IN_PROGRESS],
                :default => :yellow
 
       class << self

--- a/lib/convection/model/event.rb
+++ b/lib/convection/model/event.rb
@@ -14,7 +14,8 @@ module Convection
       attr_accessor :level
       attr_accessor :timestamp
       colorize :level,
-               :green => [:info, :success, Control::Stack::CREATE_COMPLETE, Control::Stack::UPDATE_COMPLETE, Control::Stack::UPDATE_ROLLBACK_COMPLETE, Control::Stack::TASK_COMPLETED],
+               :green => [:info, :success, Control::Stack::CREATE_COMPLETE, Control::Stack::UPDATE_COMPLETE, Control::Stack::UPDATE_ROLLBACK_COMPLETE,
+                          Control::Stack::TASK_COMPLETED],
                :red => [:error, :fail, Control::Stack::CREATE_FAILED, Control::Stack::ROLLBACK_FAILED,
                         Control::Stack::DELETE_FAILED, Control::Stack::UPDATE_FAILED,
                         Control::Stack::UPDATE_ROLLBACK_IN_PROGRESS, Control::Stack::UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS,

--- a/lib/convection/model/event.rb
+++ b/lib/convection/model/event.rb
@@ -15,7 +15,7 @@ module Convection
       attr_accessor :timestamp
       colorize :level,
                :green => [:info, :success, Control::Stack::CREATE_COMPLETE, Control::Stack::UPDATE_COMPLETE, Control::Stack::UPDATE_ROLLBACK_COMPLETE,
-                          Control::Stack::TASK_COMPLETED],
+                          Control::Stack::TASK_COMPLETE],
                :red => [:error, :fail, Control::Stack::CREATE_FAILED, Control::Stack::ROLLBACK_FAILED,
                         Control::Stack::DELETE_FAILED, Control::Stack::UPDATE_FAILED,
                         Control::Stack::UPDATE_ROLLBACK_IN_PROGRESS, Control::Stack::UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS,


### PR DESCRIPTION
Fix #146.

# Example output

<pre>ecarey ~/r/b/example-cloud (master)> bundle exec convection converge
converge  Stack vpc
update_in_progress  ecarey-test-cloud-1-vpc: (AWS::CloudFormation::Stack/arn:aws:cloudformation:eu-west-1:...:stack/ecarey-test-cloud-1-vpc/...) User Initiated
update_in_progress  TargetVPC: (AWS::EC2::VPC/vpc-deadb33f) 
update_complete  TargetVPC: (AWS::EC2::VPC/vpc-deadb33f) 
update_complete_cleanup_in_progress  ecarey-test-cloud-1-vpc: (AWS::CloudFormation::Stack/arn:aws:cloudformation:eu-west-1:...:stack/ecarey-test-cloud-1-vpc/...) 
update_complete  ecarey-test-cloud-1-vpc: (AWS::CloudFormation::Stack/arn:aws:cloudformation:eu-west-1:...:stack/ecarey-test-cloud-1-vpc/...) 
<b>task_in_progress  Task (after_update) validate-vpc-stack-outputs in progress for stack vpc.
task_complete  Task (after_update) validate-vpc-stack-outputs successfully completed for stack vpc.</b></pre>