### PR TITLE
Add yard (yardoc.org) to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development do
   gem 'rubocop', '~> 0.40.0'
   gem 'simplecov'
   gem 'thor-scmversion', '= 1.7.0'
+  gem 'yard'
 end


### PR DESCRIPTION
Use `yardoc` to generate documentation under `doc/`.