### PR TITLE
Restore early return functionality of diff/converge (lost in #169)

### DIFF
--- a/bin/convection
+++ b/bin/convection
@@ -16,7 +16,7 @@ module Convection
 
     desc 'converge STACK', 'Converge your cloud'
     option :stack_group, :type => :string, :desc => 'The name of a stack group defined in your cloudfile to converge'
-    option :stacks, :type => :string, :desc => 'A ordered space separated list of stacks to converge'
+    option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to converge'
     def converge(stack = nil)
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
       @cloud.converge(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|

--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -44,7 +44,9 @@ module Convection
 
         # if no filter is specified, return the entire deck
         return stacks if filter.empty?
-        @cloudfile.stacks.select { |name, _stack| filter.include?(name) }
+        filter.reduce({}) do |result, stack_name|
+          result.merge(stack_name => @cloudfile.stacks[stack_name])
+        end
       end
 
       def converge(to_stack, options = {}, &block)

--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -48,6 +48,11 @@ module Convection
       end
 
       def converge(to_stack, options = {}, &block)
+        if to_stack && !stacks.include?(to_stack)
+          block.call(Model::Event.new(:error, "Undefined Stack #{ to_stack }", :error)) if block
+          return
+        end
+
         filter_deck(options, &block).each_value do |stack|
           block.call(Model::Event.new(:converge, "Stack #{ stack.name }", :info)) if block
           stack.apply(&block)
@@ -67,6 +72,12 @@ module Convection
       end
 
       def diff(to_stack, options = {}, &block)
+        if to_stack && !stacks.include?(to_stack)
+          block.call(Model::Event.new(:error, "Undefined Stack #{ to_stack }", :error)) if block
+          return
+        end
+
+
         filter_deck(options, &block).each_value do |stack|
           block.call(Model::Event.new(:compare, "Compare local state of stack #{ stack.name } (#{ stack.cloud_name }) with remote template", :info))
 

--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -83,7 +83,7 @@ module Convection
 
           difference = stack.diff
           if difference.empty?
-            difference << Model::Event.new(:unchanged, "Stack #{ stack.cloud_name } Has no changes", :info)
+            difference << Model::Event.new(:unchanged, "Stack #{ stack.cloud_name } has no changes", :info)
           end
 
           difference.each { |diff| block.call(diff) }

--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -36,7 +36,7 @@ module Convection
         # throw an error if the user specifies nonexistent stacks
         if Array(options[:stacks]).any? { |name| !@cloudfile.stacks.key?(name) }
           bad_stack_names = options[:stacks].reject { |name| @cloudfile.stacks.key?(name) }
-          block.call(Model::Event.new(:error, "Non Existent Stack(s) #{bad_stack_names.join(', ')}", :error)) if block
+          block.call(Model::Event.new(:error, "Undefined Stack(s) #{bad_stack_names.join(', ')}", :error)) if block
           return {}
         end
 

--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -77,7 +77,6 @@ module Convection
           return
         end
 
-
         filter_deck(options, &block).each_value do |stack|
           block.call(Model::Event.new(:compare, "Compare local state of stack #{ stack.name } (#{ stack.cloud_name }) with remote template", :info))
 


### PR DESCRIPTION
Additionally fixes:

* A bad Thor type in `--stacks` for the `converge` subcommand.
* Some grammar/wording.