### PR TITLE
Support deleting stacks using `convection delete`

### DIFF
--- a/bin/convection
+++ b/bin/convection
@@ -46,7 +46,7 @@ module Convection
         say_status(:delete_failed, 'No stacks found matching the provided input (STACK, --stack-group, and/or --stacks).', :red)
         return
       end
-      say_status(:delete, "Deleting the following stack(s): #{stacks.inspect}", :red)
+      say_status(:delete, "Deleting the following stack(s): #{stacks.map(&:name).join(', ')}", :red)
 
       confirmation = ask('Are you sure you want to delete the above stack(s)?', limited_to: %w(yes no))
       if confirmation.eql?('yes')

--- a/bin/convection
+++ b/bin/convection
@@ -43,7 +43,7 @@ module Convection
 
       stacks = @cloud.stacks_until(stack, options, &print_status)
       if stacks.empty?
-        say_status(:delete_failed, "No stacks found matching the provided input (STACK, --stack-group, and/or --stacks).", :red)
+        say_status(:delete_failed, 'No stacks found matching the provided input (STACK, --stack-group, and/or --stacks).', :red)
         return
       end
       say_status(:delete, "Deleting the following stack(s): #{stacks.inspect}", :red)

--- a/bin/convection
+++ b/bin/convection
@@ -42,11 +42,11 @@ module Convection
       end
 
       stacks = @cloud.stacks_until(stack, options, &print_status)
-      # TODO: Does convection throw an error if no stacks are given in the cloudfile? If so this never would be hit...
       if stacks.empty?
         say_status(:delete_failed, "No stacks found matching the provided input (STACK, --stack-group, and/or --stacks).", :red)
+        return
       end
-      say_status(:delete, "deleting the following stack(s): #{stacks.inspect}", :red)
+      say_status(:delete, "Deleting the following stack(s): #{stacks.inspect}", :red)
 
       confirmation = ask('Are you sure you want to delete the above stack(s)?', limited_to: %w(yes no))
       if confirmation.eql?('yes')

--- a/bin/convection
+++ b/bin/convection
@@ -50,7 +50,7 @@ module Convection
 
       confirmation = ask('Are you sure you want to delete the above stack(s)?', limited_to: %w(yes no))
       if confirmation.eql?('yes')
-        @cloud.delete(stack, stack_group: options[:stack_group], stacks: options[:stacks], &print_status)
+        @cloud.delete(stacks, &print_status)
       else
         say_status(:delete_aborted, 'Aborted deletion of the above stack(s).', :green)
       end

--- a/bin/convection
+++ b/bin/convection
@@ -28,6 +28,34 @@ module Convection
       end
     end
 
+    desc 'delete STACK', 'Delete stack(s) from your cloud'
+    option :stack_group, :type => :string, :desc => 'The name of a stack group defined in your cloudfile to delete'
+    option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to delete'
+    def delete(stack = nil)
+      @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
+      print_status = lambda do |event, *errors|
+        say_status(*event.to_thor)
+        errors.flatten.each do |error|
+          say "* #{ error.message }"
+          error.backtrace.each { |b| say "    #{ b }" }
+        end unless errors.nil?
+      end
+
+      stacks = @cloud.stacks_until(stack, options, &print_status)
+      # TODO: Does convection throw an error if no stacks are given in the cloudfile? If so this never would be hit...
+      if stacks.empty?
+        say_status(:delete_failed, "No stacks found matching the provided input (STACK, --stack-group, and/or --stacks).", :red)
+      end
+      say_status(:delete, "deleting the following stack(s): #{stacks.inspect}", :red)
+
+      confirmation = ask('Are you sure you want to delete the above stack(s)?', limited_to: %w(yes no))
+      if confirmation.eql?('yes')
+        @cloud.delete(stack, stack_group: options[:stack_group], stacks: options[:stacks], &print_status)
+      else
+        say_status(:delete_aborted, 'Aborted deletion of the above stack(s).', :green)
+      end
+    end
+
     desc 'diff STACK', 'Show changes that will be applied by converge'
     option :verbose, :type => :boolean, :aliases => '--v', :desc => 'Show stack progress'
     option :'very-verbose', :type => :boolean, :aliases => '--vv', :desc => 'Show unchanged stacks'

--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -94,7 +94,7 @@ module Convection
 
         filter_deck(options, &block).each_value do |stack|
           if stack.exist?
-            block.call(Model::Event.new(:deleted, "Delete remote stack #{ stack.cloud_name }", :info))
+            block.call(Model::Event.new(:deleted, "Delete remote stack #{ stack.cloud_name }", :info)) if block
             stack.delete(&block)
 
             if stack.error?

--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -91,6 +91,7 @@ module Convection
         stacks.each do |stack|
           unless stack.exist?
             block.call(Model::Event.new(:delete_skipped, "Stack #{ stack.cloud_name } does not exist remotely", :warn))
+            next
           end
 
           block.call(Model::Event.new(:deleted, "Delete remote stack #{ stack.cloud_name }", :info)) if block

--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -363,11 +363,6 @@ module Convection
       # @param block [Proc] a configuration block to pass any
       #   {Convection::Model::Event}s to.
       def delete(&block)
-        unless exist?
-          block.call(Model::Event.new(:complete, "Stack #{ name } does not exist", :info)) if block
-          return
-        end
-
         ## Execute before delete tasks
         @tasks[:before_delete].delete_if do |task|
           run_task(:before_delete, task, &block)


### PR DESCRIPTION
Previously we did not expose the `Stack#delete` command in our CLI. Adds a `delete` subcommand that functions like the `diff`/`converge` commands.