### PR TITLE
Use retry limit

### DIFF
--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -123,7 +123,7 @@ module Convection
           # Find errors during diff
           if stack.error?
             errors = stack.errors.collect { |x| x.exception.message }
-            errors.uniq!.flatten!
+            errors = errors.uniq.flatten
             block.call(Model::Event.new(:error, "Error diffing stack #{ stack.name} Error(s): #{errors.join(', ')}", :error), stack.errors) if block
             break
           end
@@ -148,7 +148,7 @@ module Convection
         end
 
         unless errors.empty?
-          errors.uniq!.flatten!
+          errors = errors.uniq.flatten
           block.call(Model::Event.new(:error, "Error(s) during stack initialization #{errors.join(', ')}", :error), errors) if block
           return true
         end

--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -125,7 +125,6 @@ module Convection
           difference.each { |diff| block.call(diff) }
 
           break if !to_stack.nil? && stack.name == to_stack
-          sleep rand @cloudfile.splay || 2
         end
       end
     end

--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -120,7 +120,7 @@ module Convection
 
         @attributes = options.delete(:attributes) { |_| Model::Attributes.new }
         @options = options
-        @retry_limit = options[:retry_limit] || 25
+        @retry_limit = options[:retry_limit] || 6
 
         client_options = {}.tap do |opt|
           opt[:region] = @region

--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -120,7 +120,7 @@ module Convection
 
         @attributes = options.delete(:attributes) { |_| Model::Attributes.new }
         @options = options
-        @retry_limit = options[:retry_limit] || 6
+        @retry_limit = options[:retry_limit] || 7
 
         client_options = {}.tap do |opt|
           opt[:region] = @region

--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -120,10 +120,11 @@ module Convection
 
         @attributes = options.delete(:attributes) { |_| Model::Attributes.new }
         @options = options
-
+        @retry_limit = options[:retry_limit] || 25
         client_options = {}.tap do |opt|
           opt[:region] = @region
           opt[:credentials] = @credentials unless @credentials.nil?
+          opt[:retry_limit] = @retry_limit
         end
         @ec2_client = Aws::EC2::Client.new(client_options)
         @cf_client = Aws::CloudFormation::Client.new(client_options)

--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -121,6 +121,7 @@ module Convection
         @attributes = options.delete(:attributes) { |_| Model::Attributes.new }
         @options = options
         @retry_limit = options[:retry_limit] || 25
+
         client_options = {}.tap do |opt|
           opt[:region] = @region
           opt[:credentials] = @credentials unless @credentials.nil?

--- a/lib/convection/model/cloudfile.rb
+++ b/lib/convection/model/cloudfile.rb
@@ -14,6 +14,7 @@ module Convection
       attribute :name
       attribute :region
       attribute :splay
+      attribute :retry_limit
 
       ## Helper to define a template in-line
       def template(*args, &block)
@@ -31,7 +32,7 @@ module Convection
         options[:region] ||= region
         options[:cloud] = name
         options[:attributes] = attributes
-
+        options[:retry_limit] = retry_limit
         @stacks[stack_name] = Control::Stack.new(stack_name, template, options, &block)
         @deck << @stacks[stack_name]
       end

--- a/lib/convection/model/cloudfile.rb
+++ b/lib/convection/model/cloudfile.rb
@@ -33,6 +33,7 @@ module Convection
         options[:cloud] = name
         options[:attributes] = attributes
         options[:retry_limit] = retry_limit
+
         @stacks[stack_name] = Control::Stack.new(stack_name, template, options, &block)
         @deck << @stacks[stack_name]
       end


### PR DESCRIPTION
This should speed up diffs by about 2 seconds per stack
Use the retry logic provided by the aws sdk. See here https://github.com/aws/aws-sdk-ruby/blob/ef9f2d3655c4bacb3adff580a6b295df510f78fe/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb#L16 and https://github.com/aws/aws-sdk-ruby/blob/a3a442e0824318dcd95021a1f6057309518bf2a5/aws-sdk-core/spec/aws/s3/client_spec.rb#L15

A custom retry limit can be set in the cloudfile like below or it defaults to 6 which is a ~19 second sleep
```
retry_limit YOUR_NUMBER
```

Verification Steps
- [x] Diffs are functioning properly
- [x] Diffs are not being rate limited