### PR TITLE
When doing a diff print errors found during stack initialization

### DIFF
--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -114,6 +114,18 @@ module Convection
           return
         end
 
+        errors = []
+        stacks.each_value do |stack|
+          if stack.error?
+            errors << stack.errors.collect { |x| x.exception.message }
+          end
+        end
+        errors = errors.uniq.flatten!
+        unless errors.empty?
+          block.call(Model::Event.new(:error, "Error(s) during stack diff #{errors.join(', ')}", :error), errors) if block
+          return
+        end
+
         filter_deck(options, &block).each_value do |stack|
           block.call(Model::Event.new(:compare, "Compare local state of stack #{ stack.name } (#{ stack.cloud_name }) with remote template", :info))
 


### PR DESCRIPTION
When a instance of each stack is created it resolves a bunch of information about that stack. If the request fails because of rate limiting we do not collect the needed info. Then when doing a diff we may assume the stack does not exist or certain attributes are not set and display them as changes. This change will collect errors encountered and display them before discontinuing the diff.
Example
```
$ convection diff
       error  Error(s) during stack diff Rate exceeded
```

Verification Steps
- [x] Run diff where we are rate limited and see that the diff does not happen and a error is returned
- [x] Run a diff not rate limited and see that the diff is done.
- [x] Inject another error and see that both errors are printed.