### PR TITLE
Parallel initialisation

### DIFF
--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -69,6 +69,8 @@ module Convection
           return
         end
 
+        exit 1 if stack_initialization_errors?(&block)
+
         filter_deck(options, &block).each_value do |stack|
           block.call(Model::Event.new(:converge, "Stack #{ stack.name }", :info)) if block
           stack.apply(&block)
@@ -88,6 +90,8 @@ module Convection
       end
 
       def delete(stacks, &block)
+        exit 1 if stack_initialization_errors?(&block)
+
         stacks.each do |stack|
           unless stack.exist?
             block.call(Model::Event.new(:delete_skipped, "Stack #{ stack.cloud_name } does not exist remotely", :warn))

--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -153,18 +153,29 @@ module Convection
         #     in the dependency tree to avoid the chicken-and-egg problem.
         @template.execute
 
-        ## Get initial state
-        get_status(cloud_name)
-        return unless exist?
-
-        get_resources
-        get_template
-        resource_attributes
-        get_events(1) # Get the latest page of events (Set @last_event_seen before starting)
       rescue Aws::Errors::ServiceError => e
         @errors << e
       end
       # rubocop:enable Metrics/LineLength
+
+      def status
+        begin
+          get_status(cloud_name)
+        rescue Aws::Errors::ServiceError => e
+          @errors << e
+        end
+      end
+
+      def template_info
+        begin
+          get_resources
+          get_template
+          resource_attributes
+          get_events(1) # Get the latest page of events (Set @last_event_seen before starting)
+        rescue Aws::Errors::ServiceError => e
+          @errors << e
+        end
+      end
 
       def cloud_name
         return @cloud_name unless @cloud_name.nil?

--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -163,7 +163,7 @@ module Convection
         @errors << e
       end
 
-      def template_info
+      def load_template_info
         get_resources
         get_template
         resource_attributes

--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -156,7 +156,6 @@ module Convection
       rescue Aws::Errors::ServiceError => e
         @errors << e
       end
-      # rubocop:enable Metrics/LineLength
 
       def status
         get_status(cloud_name)
@@ -172,6 +171,7 @@ module Convection
       rescue Aws::Errors::ServiceError => e
         @errors << e
       end
+      # rubocop:enable Metrics/LineLength
 
       def cloud_name
         return @cloud_name unless @cloud_name.nil?

--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -159,22 +159,18 @@ module Convection
       # rubocop:enable Metrics/LineLength
 
       def status
-        begin
-          get_status(cloud_name)
-        rescue Aws::Errors::ServiceError => e
-          @errors << e
-        end
+        get_status(cloud_name)
+      rescue Aws::Errors::ServiceError => e
+        @errors << e
       end
 
       def template_info
-        begin
-          get_resources
-          get_template
-          resource_attributes
-          get_events(1) # Get the latest page of events (Set @last_event_seen before starting)
-        rescue Aws::Errors::ServiceError => e
-          @errors << e
-        end
+        get_resources
+        get_template
+        resource_attributes
+        get_events(1) # Get the latest page of events (Set @last_event_seen before starting)
+      rescue Aws::Errors::ServiceError => e
+        @errors << e
       end
 
       def cloud_name

--- a/lib/convection/model/cloudfile.rb
+++ b/lib/convection/model/cloudfile.rb
@@ -68,17 +68,17 @@ module Convection
         instance_eval(IO.read(cloudfile), cloudfile, 1)
 
         work_q = Queue.new
-        @deck.each { |stack| work_q.push stack }
+        @deck.each { |stack| work_q.push(stack) }
         workers = (0...@thread_count).map do
           Thread.new do
             until work_q.empty?
               stack = work_q.pop(true)
               stack.status
-              stack.template_info if stack.exist?
+              stack.load_template_info if stack.exist?
             end
           end
         end
-        workers.map(&:join)
+        workers.each(&:join)
       end
     end
   end

--- a/lib/convection/model/cloudfile.rb
+++ b/lib/convection/model/cloudfile.rb
@@ -69,6 +69,7 @@ module Convection
         @deck = []
         @stack_groups = {}
         @thread_count ||= 2
+
         instance_eval(IO.read(cloudfile), cloudfile, 1)
         work_q = Queue.new
         @deck.each { |stack| work_q.push stack }

--- a/lib/convection/model/cloudfile.rb
+++ b/lib/convection/model/cloudfile.rb
@@ -44,9 +44,6 @@ module Convection
         @stack_groups[group_name] = group_list
       end
 
-      def init_threads(count)
-        @thread_count = count
-      end
     end
   end
 
@@ -67,9 +64,10 @@ module Convection
         @stacks = {}
         @deck = []
         @stack_groups = {}
-        @thread_count ||= 2
+        @thread_count = thread_count || 2
 
         instance_eval(IO.read(cloudfile), cloudfile, 1)
+
         work_q = Queue.new
         @deck.each { |stack| work_q.push stack }
         workers = (0...@thread_count).map do

--- a/lib/convection/model/cloudfile.rb
+++ b/lib/convection/model/cloudfile.rb
@@ -43,7 +43,6 @@ module Convection
       def stack_group(group_name, group_list)
         @stack_groups[group_name] = group_list
       end
-
     end
   end
 

--- a/lib/convection/model/cloudfile.rb
+++ b/lib/convection/model/cloudfile.rb
@@ -63,7 +63,7 @@ module Convection
         @stacks = {}
         @deck = []
         @stack_groups = {}
-        @thread_count = thread_count || 2
+        @thread_count ||= 2
 
         instance_eval(IO.read(cloudfile), cloudfile, 1)
 

--- a/lib/convection/model/cloudfile.rb
+++ b/lib/convection/model/cloudfile.rb
@@ -2,7 +2,6 @@ require_relative '../control/stack'
 require_relative '../dsl/helpers'
 require_relative '../model/attributes'
 require_relative '../model/template'
-require 'Benchmark'
 require 'thread'
 
 module Convection

--- a/lib/convection/model/cloudfile.rb
+++ b/lib/convection/model/cloudfile.rb
@@ -3,7 +3,7 @@ require_relative '../dsl/helpers'
 require_relative '../model/attributes'
 require_relative '../model/template'
 require 'Benchmark'
-require 'Thread'
+require 'thread'
 
 module Convection
   module DSL
@@ -18,7 +18,6 @@ module Convection
       attribute :splay
       attribute :retry_limit
       attribute :thread_count
-
 
       ## Helper to define a template in-line
       def template(*args, &block)
@@ -69,7 +68,7 @@ module Convection
         @stacks = {}
         @deck = []
         @stack_groups = {}
-        @thread_count ||=2
+        @thread_count ||= 2
         instance_eval(IO.read(cloudfile), cloudfile, 1)
         work_q = Queue.new
         @deck.each { |stack| work_q.push stack }


### PR DESCRIPTION
# Description
Resolve stack information in parallel. This should cut the init time down almost in half. The number of threads can be set in the cloudfile with the thread_count option. The default of 2 seems to provide the best gain for the least amount of rate limiting. 

# Verification Steps
- [x] Diffs function properly
- [x] Diffs still fail when an error is encountered in init.