### PR TITLE
PD-8267 adding support for S3 cross region replication.

### DIFF
--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -23,6 +23,7 @@ module Convection
           property :lifecycle_configuration, 'LifecycleConfiguration'
           property :logging_configuration, 'LoggingConfiguration'
           property :notification_configuration, 'NotificationConfiguration'
+          property :replication_configuration, 'ReplicationConfiguration'
           property :versioning_configuration, 'VersioningConfiguration'
 
           def cors_configuration(&block)
@@ -34,6 +35,12 @@ module Convection
           def cors_configurationm(*args)
             warn 'DEPRECATED: "cors_configurationm" is deprecated. Please use "cors_configuration" instead. https://github.com/rapid7/convection/pull/135'
             cors_configuration(*args)
+          end
+
+          def replication_configuration(&block)
+            config = ResourceProperty::S3ReplicationConfiguration.new(self)
+            config.instance_exec(&block) if block
+            properties['ReplicationConfiguration'].set(config)
           end
 
           def render(*args)

--- a/lib/convection/model/template/resource_property/aws_s3_replication_configuration.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_replication_configuration.rb
@@ -4,8 +4,8 @@ module Convection
   module Model
     class Template
       class ResourceProperty
-        #Represents an {https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration.html}
-        #Amazon S3 Replication Configuration
+        # Represents an {https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration.html}
+        # Amazon S3 Replication Configuration
         class S3ReplicationConfiguration < ResourceProperty
           property :role, 'Role'
           property :rules, 'Rules', :type => :list

--- a/lib/convection/model/template/resource_property/aws_s3_replication_configuration.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_replication_configuration.rb
@@ -1,0 +1,22 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        #Represents an {https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration.html}
+        #Amazon S3 Replication Configuration
+        class S3ReplicationConfiguration < ResourceProperty
+          property :role, 'Role'
+          property :rules, 'Rules', :type => :list
+
+          def rule(&block)
+            rule = ResourceProperty::S3ReplicationConfigurationRule.new(self)
+            rule.instance_exec(&block) if block
+            rules << rule
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_replication_configuration_rule.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_replication_configuration_rule.rb
@@ -4,8 +4,8 @@ module Convection
   module Model
     class Template
       class ResourceProperty
-        #Represents an {https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration-rules.html}
-        #Amazon S3 Replication Configuration Rules
+        # Represents an {https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration-rules.html}
+        # Amazon S3 Replication Configuration Rules
         class S3ReplicationConfigurationRule < ResourceProperty
           property :destination, 'Destination'
           property :id, 'Id'

--- a/lib/convection/model/template/resource_property/aws_s3_replication_configuration_rule.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_replication_configuration_rule.rb
@@ -1,0 +1,24 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        #Represents an {https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration-rules.html}
+        #Amazon S3 Replication Configuration Rules
+        class S3ReplicationConfigurationRule < ResourceProperty
+          property :destination, 'Destination'
+          property :id, 'Id'
+          property :prefix, 'Prefix'
+          property :status, 'Status'
+
+          def destination(&block)
+            destination_bucket = ResourceProperty::S3ReplicationConfigurationRuleDestination.new(self)
+            destination_bucket.instance_exec(&block) if block
+            properties['Destination'].set(destination_bucket)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_replication_configuration_rule_destination.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_replication_configuration_rule_destination.rb
@@ -4,8 +4,9 @@ module Convection
   module Model
     class Template
       class ResourceProperty
-        #Represents an {https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration-rules-destination.html}
-        #Amazon S3 Replication Configuration Rules Destination
+        # Represents an
+        # {https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration-rules-destination.html}
+        # Amazon S3 Replication Configuration Rules Destination
         class S3ReplicationConfigurationRuleDestination < ResourceProperty
           property :bucket, 'Bucket'
           property :storage_class, 'StorageClass'

--- a/lib/convection/model/template/resource_property/aws_s3_replication_configuration_rule_destination.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_replication_configuration_rule_destination.rb
@@ -1,0 +1,16 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        #Represents an {https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-replicationconfiguration-rules-destination.html}
+        #Amazon S3 Replication Configuration Rules Destination
+        class S3ReplicationConfigurationRuleDestination < ResourceProperty
+          property :bucket, 'Bucket'
+          property :storage_class, 'StorageClass'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
See [PD-8267](https://issues.corp.rapid7.com/browse/PD-8267)

Resource properties to support [S3 replication configuration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-replicationconfiguration) (configuration for replicating objects in an S3 bucket).