### PR TITLE
Fix #194 - support autoscaling tags

### DIFF
--- a/spec/convection/model/template/resource/aws_auto_scaling_auto_scaling_group_spec.rb
+++ b/spec/convection/model/template/resource/aws_auto_scaling_auto_scaling_group_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+class Convection::Model::Template::Resource
+  describe AutoScalingGroup do
+    subject do
+      parent = double(:template)
+      allow(parent).to receive(:template).and_return(parent)
+
+      described_class.new('MyAutoScalingGroup', parent)
+    end
+
+    it 'should not render tags when none have been defined' do
+      expect(subject.render['Properties']['Tags']).to be_nil
+    end
+
+    it 'renders a regular tag' do
+      subject.tag '<tag-name>', '<tag-value>'
+      expect(subject.render['Properties']['Tags']).to include(a_hash_including('Key' => '<tag-name>'))
+    end
+
+    it 'renders a tag that should be propagated at launch' do
+      subject.tag '<tag-name>', '<tag-value>', propagate_at_launch: true
+      expect(subject.render['Properties']['Tags']).to include(a_hash_including('Key' => '<tag-name>', 'PropagateAtLaunch' => true))
+    end
+
+    it 'renders a tag that should not be propagated at launch' do
+      subject.tag '<tag-name>', '<tag-value>', propagate_at_launch: false
+      expect(subject.render['Properties']['Tags']).to include(a_hash_including('Key' => '<tag-name>', 'PropagateAtLaunch' => false))
+    end
+  end
+end


### PR DESCRIPTION
# Description
Fix #194 by accepting a new, optional,`:propagate_at_launch` parameter in calls to the `AutoScalingGroup#tag` method.

# Motivation and Context
In CloudFormation the [Auto Scaling Tags type](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-tags.html#cfn-as-tags-PropagateAtLaunch) includes an additional `PropagateAtLaunch` property.

# Usage Examples
```ruby
tag 'MyTagName', 'MyValue', propagate_at_launch: true
```

# Testing Steps
Run `bundle exec spec` after checking out 796bde2 and 8795d93 and note the two failures found in 796bde2 being resolved once we update the `AutoScalingGroup#tag` method to include a new parameter. Also notice that the existing specs still pass.