### PR TITLE
Fix #196 - Support cross stack references

### DIFF
--- a/lib/convection/dsl/intrinsic_functions.rb
+++ b/lib/convection/dsl/intrinsic_functions.rb
@@ -27,6 +27,12 @@ module Convection
         }
       end
 
+      def fn_import_value(value)
+        {
+          'Fn::ImportValue' => value
+        }
+      end
+
       def fn_not(condition)
         {
           'Fn::Not' => [condition]

--- a/lib/convection/model/template/output.rb
+++ b/lib/convection/model/template/output.rb
@@ -15,6 +15,7 @@ module Convection
         attribute :name
         attribute :value
         attribute :description
+        attribute :export_as
         attr_reader :template
 
         def initialize(name, parent)
@@ -31,6 +32,7 @@ module Convection
             'Description' => description
           }.tap do |output|
             render_condition(output)
+            output['Export'] = { 'Name' => export_as } if export_as
           end
         end
       end

--- a/lib/convection/model/template/resource.rb
+++ b/lib/convection/model/template/resource.rb
@@ -337,11 +337,10 @@ module Convection
           }
         end
 
-        def with_output(output_name = name, value = reference, export_as: nil, &block)
+        def with_output(output_name = name, value = reference, &block)
           o = Model::Template::Output.new(output_name, @template)
           o.value = value
           o.description = "Resource #{ type }/#{ name }"
-          o.export_as = export_as if export_as
 
           o.instance_exec(&block) if block
           @template.outputs[output_name] = o

--- a/lib/convection/model/template/resource.rb
+++ b/lib/convection/model/template/resource.rb
@@ -337,10 +337,11 @@ module Convection
           }
         end
 
-        def with_output(output_name = name, value = reference, &block)
+        def with_output(output_name = name, value = reference, export_as: nil, &block)
           o = Model::Template::Output.new(output_name, @template)
           o.value = value
           o.description = "Resource #{ type }/#{ name }"
+          o.export_as = export_as if export_as
 
           o.instance_exec(&block) if block
           @template.outputs[output_name] = o


### PR DESCRIPTION
# Description
Fix #196 - Add support for the new `Export` `Outputs` property and the `Fn::ImportValue` function.

* See also the [Fn::ImportValue](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html) documentation.
* See also the [Export section of the Outputs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html) documentation.

<!-- Include references to relevant pull requests/commits here. -->
<!-- * Did you update documentation? -->
<!-- * Did you update test coverage? -->

# Motivation and Context
To simplify cross-stack references written in Convection templates by leveraging the new addition to CloudFormation.