### PR TITLE
Fix #198 - Warn users of manually creating predefined resources

### DIFF
--- a/spec/convection/model/template/condition_spec.rb
+++ b/spec/convection/model/template/condition_spec.rb
@@ -10,8 +10,7 @@ class Convection::Model::Template
           fn_equals 'prod', 'prod'
         end
 
-        resource 'SecurityGroup' do
-          type 'AWS::EC2::SecurityGroup'
+        ec2_security_group 'SecurityGroup' do
           condition 'InProd'
         end
       end

--- a/spec/convection/model/template/template_spec.rb
+++ b/spec/convection/model/template/template_spec.rb
@@ -19,6 +19,36 @@ class Convection::Model::Template
       end
     end
 
+    describe '#resource' do
+      context 'when defining a predefined resource' do
+        subject do
+          Convection.template do
+            resource 'FooInstance' do
+              type 'AWS::EC2::Instance'
+            end
+          end
+        end
+
+        it 'warns the user when they are using a predefined resource.' do
+          expect { subject.render }.to output(/.*already defined.*/).to_stderr
+        end
+      end
+
+      context 'when defining a undefined resource' do
+        subject do
+          Convection.template do
+            resource 'FooInstance' do
+              type 'FakeResource'
+            end
+          end
+        end
+
+        it 'warns the user when they are using a undefined resource.' do
+          expect { subject.render }.to_not output.to_stderr
+        end
+      end
+    end
+
     subject do
       template_json
     end

--- a/spec/convection/model/template/validate_bytesize_spec.rb
+++ b/spec/convection/model/template/validate_bytesize_spec.rb
@@ -21,13 +21,13 @@ class Convection::Model::Template
           description 'Validations Test Template - Excessive Bytesize'
 
           200.times do |count|
-            resource "EC2_INSTANCE_#{count}" do
-              type 'AWS::EC2::Instance'
-              property 'AvailabilityZone', 'us-east-1a'
+            ec2_instance "EC2_INSTANCE_#{count}" do
+              availability_zone 'us-east-1a'
               property 'ImageId', 'ami-76e27e1e'
               property 'KeyName', 'test'
-              property 'SecurityGroupIds', ['sg-dd733c41', 'sg-dd738df3']
-              property 'Tags', [{ 'Key' => 'Name', 'Value' => 'test-1' }]
+              security_group 'sg-dd733c41'
+              security_group 'sg-dd738df3'
+              tag 'Name', 'test-1'
             end
           end
 


### PR DESCRIPTION
# Description
Fix #198 - Warn users of when they redefine resources.