### PR TITLE
Fix accidental overloading of status breaking converges

### DIFF
--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -149,7 +149,7 @@ module Convection
         @errors << e
       end
 
-      def status
+      def template_status
         get_status(cloud_name)
       rescue Aws::Errors::ServiceError => e
         @errors << e

--- a/lib/convection/model/cloudfile.rb
+++ b/lib/convection/model/cloudfile.rb
@@ -73,7 +73,7 @@ module Convection
           Thread.new do
             until work_q.empty?
               stack = work_q.pop(true)
-              stack.status
+              stack.template_status
               stack.load_template_info if stack.exist?
             end
           end


### PR DESCRIPTION
<!-- Remove any sections that do not apply to your changes. HTML comments are ignored. -->
# Description
Fix accidental overloading of status. This causes issues in converge as in_progress? needs status and calls the incorrect one(mine).

# Motivation and Context
Converges are broken
# Testing Steps
Converges work again
