### PR TITLE
Fix #185 - Use a nonzero exit code when failing to diff/converge

### DIFF
--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -66,7 +66,7 @@ module Convection
       def converge(to_stack, options = {}, &block)
         if to_stack && !stacks.include?(to_stack)
           block.call(Model::Event.new(:error, "Undefined Stack #{ to_stack }", :error)) if block
-          return
+          exit 1
         end
 
         exit 1 if stack_initialization_errors?(&block)
@@ -77,11 +77,11 @@ module Convection
 
           if stack.error?
             block.call(Model::Event.new(:error, "Error converging stack #{ stack.name }", :error), stack.errors) if block
-            break
+            exit 1
           end
 
           ## Stop on converge error
-          break unless stack.success?
+          exit 1 unless stack.success?
 
           ## Stop here
           break if !to_stack.nil? && stack.name == to_stack
@@ -103,10 +103,10 @@ module Convection
 
           if stack.error?
             block.call(Model::Event.new(:error, "Error deleting stack #{ stack.name }", :error), stack.errors) if block
-            break
+            exit 1
           end
 
-          break unless stack.delete_success?
+          exit 1 unless stack.delete_success?
 
           sleep rand @cloudfile.splay || 2
         end
@@ -115,7 +115,7 @@ module Convection
       def diff(to_stack, options = {}, &block)
         if to_stack && !stacks.include?(to_stack)
           block.call(Model::Event.new(:error, "Undefined Stack #{ to_stack }", :error)) if block
-          return
+          exit 1
         end
 
         exit 1 if stack_initialization_errors?(&block)
@@ -129,7 +129,7 @@ module Convection
             errors = stack.errors.collect { |x| x.exception.message }
             errors = errors.uniq.flatten
             block.call(Model::Event.new(:error, "Error diffing stack #{ stack.name} Error(s): #{errors.join(', ')}", :error), stack.errors) if block
-            break
+            exit 1
           end
 
           if difference.empty?


### PR DESCRIPTION
# Description
Fix #185 — Use `Kernel#exit` instead of early `return`s or `break`s to ensure a non-zero exit code.