### PR TITLE
Fix #204 - Define a no_commands helper #emit_events

### DIFF
--- a/bin/convection
+++ b/bin/convection
@@ -21,16 +21,18 @@ module Convection
     option :'very-verbose', :type => :boolean, :aliases => '--vv', :desc => 'Show unchanged stacks', default: true
     def converge(stack = nil)
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
-      @cloud.converge(stack, stack_group: options[:stack_group], stacks: options[:stacks], &emit_events)
+      @cloud.converge(stack, stack_group: options[:stack_group], stacks: options[:stacks], &method(:emit_events))
     end
 
     desc 'delete STACK', 'Delete stack(s) from your cloud'
     option :stack_group, :type => :string, :desc => 'The name of a stack group defined in your cloudfile to delete'
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to delete'
+    option :verbose, :type => :boolean, :aliases => '--v', :desc => 'Show stack progress', default: true
+    option :'very-verbose', :type => :boolean, :aliases => '--vv', :desc => 'Show unchanged stacks', default: true
     def delete(stack = nil)
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
 
-      stacks = @cloud.stacks_until(stack, options, &emit_events)
+      stacks = @cloud.stacks_until(stack, options, &method(:emit_events))
       if stacks.empty?
         say_status(:delete_failed, 'No stacks found matching the provided input (STACK, --stack-group, and/or --stacks).', :red)
         return
@@ -39,20 +41,20 @@ module Convection
 
       confirmation = ask('Are you sure you want to delete the above stack(s)?', limited_to: %w(yes no))
       if confirmation.eql?('yes')
-        @cloud.delete(stacks, &emit_events)
+        @cloud.delete(stacks, &method(:emit_events))
       else
         say_status(:delete_aborted, 'Aborted deletion of the above stack(s).', :green)
       end
     end
 
     desc 'diff STACK', 'Show changes that will be applied by converge'
-    option :verbose, :type => :boolean, :aliases => '--v', :desc => 'Show stack progress'
-    option :'very-verbose', :type => :boolean, :aliases => '--vv', :desc => 'Show unchanged stacks'
     option :stack_group, :type => :string, :desc => 'The name of a stack group defined in your cloudfile to diff'
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to diff'
+    option :verbose, :type => :boolean, :aliases => '--v', :desc => 'Show stack progress'
+    option :'very-verbose', :type => :boolean, :aliases => '--vv', :desc => 'Show unchanged stacks'
     def diff(stack = nil)
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
-      @cloud.diff(stack, stack_group: options[:stack_group], stacks: options[:stacks], &emit_events)
+      @cloud.diff(stack, stack_group: options[:stack_group], stacks: options[:stacks], &method(:emit_events))
     end
 
     desc 'print STACK', 'Print the rendered template for STACK'

--- a/bin/convection
+++ b/bin/convection
@@ -17,15 +17,11 @@ module Convection
     desc 'converge STACK', 'Converge your cloud'
     option :stack_group, :type => :string, :desc => 'The name of a stack group defined in your cloudfile to converge'
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to converge'
+    option :verbose, :type => :boolean, :aliases => '--v', :desc => 'Show stack progress', default: true
+    option :'very-verbose', :type => :boolean, :aliases => '--vv', :desc => 'Show unchanged stacks', default: true
     def converge(stack = nil)
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
-      @cloud.converge(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|
-        say_status(*event.to_thor)
-        errors.each do |error|
-          say "* #{ error.message }"
-          error.backtrace.each { |b| say "    #{ b }" }
-        end unless errors.nil?
-      end
+      @cloud.converge(stack, stack_group: options[:stack_group], stacks: options[:stacks], &emit_events)
     end
 
     desc 'delete STACK', 'Delete stack(s) from your cloud'
@@ -33,15 +29,8 @@ module Convection
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to delete'
     def delete(stack = nil)
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
-      print_status = lambda do |event, *errors|
-        say_status(*event.to_thor)
-        errors.flatten.each do |error|
-          say "* #{ error.message }"
-          error.backtrace.each { |b| say "    #{ b }" }
-        end unless errors.nil?
-      end
 
-      stacks = @cloud.stacks_until(stack, options, &print_status)
+      stacks = @cloud.stacks_until(stack, options, &emit_events)
       if stacks.empty?
         say_status(:delete_failed, 'No stacks found matching the provided input (STACK, --stack-group, and/or --stacks).', :red)
         return
@@ -50,7 +39,7 @@ module Convection
 
       confirmation = ask('Are you sure you want to delete the above stack(s)?', limited_to: %w(yes no))
       if confirmation.eql?('yes')
-        @cloud.delete(stacks, &print_status)
+        @cloud.delete(stacks, &emit_events)
       else
         say_status(:delete_aborted, 'Aborted deletion of the above stack(s).', :green)
       end
@@ -63,26 +52,7 @@ module Convection
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to diff'
     def diff(stack = nil)
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
-      last_event = nil
-
-      @cloud.diff(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |d|
-        if d.is_a? Model::Event
-          if options[:'very-verbose'] || d.name == :error
-            say_status(*d.to_thor)
-          elsif options[:verbose]
-            say_status(*d.to_thor) if d.name == :compare
-          end
-          last_event = d
-        elsif d.is_a? Model::Diff
-          if !options[:'very-verbose'] && !options[:verbose]
-            say_status(*last_event.to_thor) unless last_event.nil?
-            last_event = nil
-          end
-          say_status(*d.to_thor)
-        else
-          say_status(*d.to_thor)
-        end
-      end
+      @cloud.diff(stack, stack_group: options[:stack_group], stacks: options[:stacks], &emit_events)
     end
 
     desc 'print STACK', 'Print the rendered template for STACK'
@@ -95,6 +65,34 @@ module Convection
     def validate(stack)
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
       @cloud.stacks[stack].validate
+    end
+
+    no_commands do
+      attr_accessor :last_event
+
+      def emit_events(event, *errors)
+        if event.is_a? Model::Event
+          if options[:'very-verbose'] || event.name == :error
+            say_status(*event.to_thor)
+          elsif options[:verbose]
+            say_status(*event.to_thor) if event.name == :compare
+          end
+          @last_event = event
+        elsif event.is_a? Model::Diff
+          if !options[:'very-verbose'] && !options[:verbose]
+            say_status(*last_event.to_thor) unless last_event.nil?
+            @last_event = nil
+          end
+          say_status(*event.to_thor)
+        else
+          say_status(*event.to_thor)
+        end
+
+        errors.each do |error|
+          say "* #{ error.message }"
+          error.backtrace.each { |trace| say "    #{ trace }" }
+        end
+      end
     end
   end
 end

--- a/bin/convection
+++ b/bin/convection
@@ -72,6 +72,8 @@ module Convection
     no_commands do
       attr_accessor :last_event
 
+      private
+
       def emit_events(event, *errors)
         if event.is_a? Model::Event
           if options[:'very-verbose'] || event.name == :error


### PR DESCRIPTION
# Description
Define a new `#emit_events` auxiliary method for printing out `Model::Diff` and `Model::Event` events.