### PR TITLE
Parallel cloudfile diffs and converges

### DIFF
--- a/bin/convection
+++ b/bin/convection
@@ -21,12 +21,12 @@ module Convection
     option :verbose, :type => :boolean, :aliases => '--v', :desc => 'Show stack progress', default: true
     option :'very-verbose', :type => :boolean, :aliases => '--vv', :desc => 'Show unchanged stacks', default: true
     option :cloudfiles, :type => :array, :default => %w(Cloudfile)
-    option :delayed_output, :type => :boolean, :desc => 'Delay output until operation completion. Makes output easier to read if operating on multiple cloudfiles', :default => true
+    option :delayed_output, :type => :boolean, :desc => 'Delay output until operation completion.', :default => true
     def converge(stack = nil)
       outputs = []
       semaphore = Mutex.new
       work_q = Queue.new
-      options[:cloudfiles].each {|cloudfile| work_q.push({cloud: Control::Cloud.new, cloudfile_path: cloudfile}) }
+      options[:cloudfiles].each { |cloudfile| work_q.push(cloud: Control::Cloud.new, cloudfile_path: cloudfile) }
       workers = (0...options[:cloudfiles].length).map do
         Thread.new do
           output = []
@@ -36,23 +36,20 @@ module Convection
             cloud = cloud_array[:cloud]
             cloud.converge(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|
               if options[:cloudfiles].length > 1 && options[:delayed_output]
-                output <<  {event: event, errors: errors}
+                output << { event: event, errors: errors }
               else
                 emit_events(event, *errors, region: cloud.cloudfile.region)
               end
-              semaphore.synchronize {
-                if @errors == false && errors
-                  @errors = true
-                end
-              }
+              semaphore.synchronize { @errors = true if @errors == false && errors }
             end
-            semaphore.synchronize { outputs << {region: cloud.cloudfile.region, logging: output} } if options[:cloudfiles].length > 1 && options[:delayed_output]
+            if options[:cloudfiles].length > 1 && options[:delayed_output]
+              semaphore.synchronize { outputs << { region: cloud.cloudfile.region, logging: output } }
+            end
           end
         end
-
       end
       workers.each(&:join)
-      print_outputs(outputs) if outputs.length > 0
+      print_outputs(outputs) unless outputs.empty?
       exit 1 if @errors
     end
 
@@ -87,12 +84,12 @@ module Convection
     option :verbose, :type => :boolean, :aliases => '--v', :desc => 'Show stack progress'
     option :'very-verbose', :type => :boolean, :aliases => '--vv', :desc => 'Show unchanged stacks'
     option :cloudfiles, :type => :array, :default => %w(Cloudfile)
-    option :delayed_output, :type => :boolean, :desc => 'Delay output until operation completion. Makes output easier to read if operating on multiple cloudfiles', :default => true
+    option :delayed_output, :type => :boolean, :desc => 'Delay output until operation completion.', :default => true
     def diff(stack = nil)
       outputs = []
       semaphore = Mutex.new
       work_q = Queue.new
-      options[:cloudfiles].each {|cloudfile| work_q.push({cloud: Control::Cloud.new, cloudfile_path: cloudfile}) }
+      options[:cloudfiles].each { |cloudfile| work_q.push(cloud: Control::Cloud.new, cloudfile_path: cloudfile) }
       workers = (0...options[:cloudfiles].length).map do
         Thread.new do
           until work_q.empty?
@@ -102,22 +99,20 @@ module Convection
             cloud = cloud_array[:cloud]
             cloud.diff(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|
               if options[:cloudfiles].length > 1 && options[:delayed_output]
-                output <<  {event: event, errors: errors}
+                output << { event: event, errors: errors }
               else
                 emit_events(event, *errors, region: cloud.cloudfile.region)
               end
-              semaphore.synchronize {
-                if @errors == false && errors
-                  @errors = true
-                end
-              }
+              semaphore.synchronize { @errors = true if @errors == false && errors }
             end
-            semaphore.synchronize { outputs << {region: cloud.cloudfile.region, logging: output} } if options[:cloudfiles].length > 1 && options[:delayed_output]
+            if options[:cloudfiles].length > 1 && options[:delayed_output]
+              semaphore.synchronize { outputs << { region: cloud.cloudfile.region, logging: output } }
+            end
           end
         end
       end
       workers.each(&:join)
-      print_outputs(outputs) if outputs.length > 0
+      print_outputs(outputs) unless outputs.empty?
       exit 1 if @errors
     end
 
@@ -136,14 +131,13 @@ module Convection
     end
 
     no_commands do
-
       attr_accessor :last_event
 
       private
+
       def init_cloud
         @cloud = Control::Cloud.new
       end
-
 
       def emit_events(event, *errors, region: nil)
         if event.is_a? Model::Event
@@ -176,9 +170,9 @@ module Convection
 
       def print_outputs(outputs)
         outputs.each do |output|
-          puts "********"
+          puts '********'
           puts output[:region]
-          puts "********"
+          puts '********'
           output[:logging].each do |hash|
             emit_events(hash[:event], *hash[:errors])
           end

--- a/bin/convection
+++ b/bin/convection
@@ -21,14 +21,28 @@ module Convection
     option :stack_group, :type => :string, :desc => 'The name of a stack group defined in your cloudfile to converge'
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to converge'
     def converge(stack = nil)
-      @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
-      @cloud.converge(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|
-        say_status(*event.to_thor)
-        errors.each do |error|
-          say "* #{ error.message }"
-          error.backtrace.each { |b| say "    #{ b }" }
-        end unless errors.nil?
+      semaphore = Mutex.new
+      work_q = Queue.new
+      options[:cloudfiles].each {|cloudfile| work_q.push({cloud: Control::Cloud.new, cloudfile_path: cloudfile}) }
+      workers = (0...options[:cloudfiles].length).map do
+        Thread.new do
+          until work_q.empty?
+            cloud_array = work_q.pop(true)
+            cloud_array[:cloud].configure(File.absolute_path(cloud_array[:cloudfile_path], @cwd))
+            cloud = cloud_array[:cloud]
+            cloud.converge(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|
+              semaphore.synchronize {
+                say_status(*event.to_thor)
+                errors.each do |error|
+                  say "* #{ error.message }"
+                  error.backtrace.each { |b| say "    #{ b }" }
+                end unless errors.nil?
+              }
+            end
+          end
+        end
       end
+      workers.each(&:join)
     end
 
     desc 'delete STACK', 'Delete stack(s) from your cloud'

--- a/bin/convection
+++ b/bin/convection
@@ -106,9 +106,9 @@ module Convection
       def operation(task_name, stack)
         work_q = Queue.new
         semaphore = Mutex.new
-        if options[:delayed_output]
-          puts 'For easier reading when using multiple cloudfiles output will be delayed until task completion.'.red
-          puts 'If you would like immediate output please use the "--delayed_output false" option.'.red
+        if options[:cloudfiles].length > 1 && options[:delayed_output]
+          puts 'For easier reading when using multiple cloudfiles output will be delayed until task completion.'
+          puts 'If you would like immediate output please use the "--delayed_output false" option.'
         end
         options[:cloudfiles].each { |cloudfile| work_q.push(cloud: Control::Cloud.new, cloudfile_path: cloudfile) }
         workers = (0...options[:cloudfiles].length).map do
@@ -122,7 +122,7 @@ module Convection
                 if options[:cloudfiles].length > 1 && options[:delayed_output]
                   output << { event: event, errors: errors }
                 else
-                  emit_events(event, *errors, region: cloud.cloudfile.region)
+                  emit_events(event, *errors)
                 end
                 semaphore.synchronize { @errors = errors.any? if errors }
               end

--- a/bin/convection
+++ b/bin/convection
@@ -1,16 +1,19 @@
 #!/usr/bin/env ruby
 require 'thor'
 require_relative '../lib/convection/control/cloud'
-
+require 'thread'
+require 'pp'
+require 'benchmark'
 module Convection
   ##
   # Convection CLI
   ##
   class CLI < Thor
     class_option :cloudfile, :type => :string, :default => 'Cloudfile'
+    class_option :cloudfiles, :type => :array
     def initialize(*args)
       super
-      @cloud = Control::Cloud.new
+      #@cloud = Control::Cloud.new
       @cwd = Dir.getwd
     end
 
@@ -62,27 +65,43 @@ module Convection
     option :stack_group, :type => :string, :desc => 'The name of a stack group defined in your cloudfile to diff'
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to diff'
     def diff(stack = nil)
-      @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
-      last_event = nil
-
-      @cloud.diff(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |d|
-        if d.is_a? Model::Event
-          if options[:'very-verbose'] || d.name == :error
-            say_status(*d.to_thor)
-          elsif options[:verbose]
-            say_status(*d.to_thor) if d.name == :compare
-          end
-          last_event = d
-        elsif d.is_a? Model::Diff
-          if !options[:'very-verbose'] && !options[:verbose]
-            say_status(*last_event.to_thor) unless last_event.nil?
+      time = Benchmark.realtime do
+      semaphore = Mutex.new
+      work_q = Queue.new
+      options[:cloudfiles].each {|cloudfile| work_q.push({cloud: Control::Cloud.new, cloudfile_path: cloudfile}) }
+      workers = (0...options[:cloudfiles].length).map do
+        Thread.new do
+          until work_q.empty?
+            cloud_array = work_q.pop(true)
+            cloud_array[:cloud].configure(File.absolute_path(cloud_array[:cloudfile_path], @cwd))
             last_event = nil
+            cloud = cloud_array[:cloud]
+            cloud.diff(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |d|
+              semaphore.synchronize {
+              if d.is_a? Model::Event
+                if options[:'very-verbose'] || d.name == :error
+                  say_status(*d.to_thor)
+                elsif options[:verbose]
+                  say_status(*d.to_thor) if d.name == :compare
+                end
+                last_event = d
+              elsif d.is_a? Model::Diff
+                if !options[:'very-verbose'] && !options[:verbose]
+                  say_status(*last_event.to_thor) unless last_event.nil?
+                  last_event = nil
+                end
+                say_status(*d.to_thor)
+              else
+                say_status(*d.to_thor)
+              end
+              }
+            end
           end
-          say_status(*d.to_thor)
-        else
-          say_status(*d.to_thor)
         end
       end
+      workers.each(&:join)
+      end
+      puts "Diff time = #{time*1000} ms"
     end
 
     desc 'print STACK', 'Print the rendered template for STACK'

--- a/bin/convection
+++ b/bin/convection
@@ -2,8 +2,6 @@
 require 'thor'
 require_relative '../lib/convection/control/cloud'
 require 'thread'
-require 'pp'
-require 'benchmark'
 module Convection
   ##
   # Convection CLI

--- a/bin/convection
+++ b/bin/convection
@@ -19,28 +19,45 @@ module Convection
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to converge'
     option :cloudfiles, :type => :array, :default => %w(Cloudfile)
     def converge(stack = nil)
+      outputs = []
       semaphore = Mutex.new
       work_q = Queue.new
       options[:cloudfiles].each {|cloudfile| work_q.push({cloud: Control::Cloud.new, cloudfile_path: cloudfile}) }
       workers = (0...options[:cloudfiles].length).map do
         Thread.new do
+          output = []
           until work_q.empty?
             cloud_array = work_q.pop(true)
             cloud_array[:cloud].configure(File.absolute_path(cloud_array[:cloudfile_path], @cwd))
             cloud = cloud_array[:cloud]
             cloud.converge(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|
-              semaphore.synchronize {
-                say_status(*event.to_thor)
-                errors.each do |error|
-                  say "* #{ error.message }"
-                  error.backtrace.each { |b| say "    #{ b }" }
-                end unless errors.nil?
-              }
+              output <<  {event: event, errors: errors}
             end
+            semaphore.synchronize {
+              outputs << {region: cloud.cloudfile.region, logging: output}
+            }
           end
         end
+
       end
       workers.each(&:join)
+      error_count = 0
+      outputs.each do |output|
+        puts "********"
+        puts output[:region]
+        puts "********"
+        output[:logging].each do |hash|
+          say_status(*hash[:event].to_thor)
+          hash[:errors].each do |error|
+            error_count +=1
+          say "* #{ error.message }"
+          error.backtrace.each { |b| say "    #{ b }" }
+          end unless hash[:errors].nil?
+        end
+      end
+      if error_count > 0
+        exit 1
+      end
     end
 
     desc 'delete STACK', 'Delete stack(s) from your cloud'
@@ -118,7 +135,9 @@ module Convection
       end
       workers.each(&:join)
       outputs.each do |output|
+        puts "********"
         puts output[:region]
+        puts "********"
         output[:logging].each do |status|
           say_status(*status.to_thor)
         end

--- a/bin/convection
+++ b/bin/convection
@@ -2,6 +2,7 @@
 require 'thor'
 require_relative '../lib/convection/control/cloud'
 require 'thread'
+require 'colorize'
 module Convection
   ##
   # Convection CLI
@@ -21,33 +22,7 @@ module Convection
     option :cloudfiles, :type => :array, :default => %w(Cloudfile)
     option :delayed_output, :type => :boolean, :desc => 'Delay output until operation completion.', :default => true
     def converge(stack = nil)
-      outputs = []
-      semaphore = Mutex.new
-      work_q = Queue.new
-      options[:cloudfiles].each { |cloudfile| work_q.push(cloud: Control::Cloud.new, cloudfile_path: cloudfile) }
-      workers = (0...options[:cloudfiles].length).map do
-        Thread.new do
-          output = []
-          until work_q.empty?
-            cloud_array = work_q.pop(true)
-            cloud_array[:cloud].configure(File.absolute_path(cloud_array[:cloudfile_path], @cwd))
-            cloud = cloud_array[:cloud]
-            cloud.converge(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|
-              if options[:cloudfiles].length > 1 && options[:delayed_output]
-                output << { event: event, errors: errors }
-              else
-                emit_events(event, *errors, region: cloud.cloudfile.region)
-              end
-              semaphore.synchronize { @errors = errors.any? }
-            end
-            if options[:cloudfiles].length > 1 && options[:delayed_output]
-              semaphore.synchronize { outputs << { region: cloud.cloudfile.region, logging: output } }
-            end
-          end
-        end
-      end
-      workers.each(&:join)
-      print_outputs(outputs) if outputs.any?
+      task('converge', stack)
       exit 1 if @errors
     end
 
@@ -83,33 +58,7 @@ module Convection
     option :cloudfiles, :type => :array, :default => %w(Cloudfile)
     option :delayed_output, :type => :boolean, :desc => 'Delay output until operation completion.', :default => true
     def diff(stack = nil)
-      outputs = []
-      semaphore = Mutex.new
-      work_q = Queue.new
-      options[:cloudfiles].each { |cloudfile| work_q.push(cloud: Control::Cloud.new, cloudfile_path: cloudfile) }
-      workers = (0...options[:cloudfiles].length).map do
-        Thread.new do
-          until work_q.empty?
-            output = []
-            cloud_array = work_q.pop(true)
-            cloud_array[:cloud].configure(File.absolute_path(cloud_array[:cloudfile_path], @cwd))
-            cloud = cloud_array[:cloud]
-            cloud.diff(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|
-              if options[:cloudfiles].length > 1 && options[:delayed_output]
-                output << { event: event, errors: errors }
-              else
-                emit_events(event, *errors, region: cloud.cloudfile.region)
-              end
-              semaphore.synchronize { @errors = errors.any? }
-            end
-            if options[:cloudfiles].length > 1 && options[:delayed_output]
-              semaphore.synchronize { outputs << { region: cloud.cloudfile.region, logging: output } }
-            end
-          end
-        end
-      end
-      workers.each(&:join)
-      print_outputs(outputs) if outputs.any?
+      task('diff', stack)
       exit 1 if @errors
     end
 
@@ -132,9 +81,37 @@ module Convection
 
       private
 
-      def init_cloud
-        @cloud = Control::Cloud.new
-        @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
+      def task(task_name, stack)
+        outputs = []
+        work_q = Queue.new
+        semaphore = Mutex.new
+        if options[:delayed_output]
+          puts 'For easier reading when using multiple cloudfiles output will be delayed until task completion. If you would like immediate output please use the "--delayed_output false" option.'.red
+        end
+        options[:cloudfiles].each { |cloudfile| work_q.push(cloud: Control::Cloud.new, cloudfile_path: cloudfile) }
+        workers = (0...options[:cloudfiles].length).map do
+          Thread.new do
+            until work_q.empty?
+              output = []
+              cloud_array = work_q.pop(true)
+              cloud_array[:cloud].configure(File.absolute_path(cloud_array[:cloudfile_path], @cwd))
+              cloud = cloud_array[:cloud]
+              cloud.send(task_name, stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|
+                if options[:cloudfiles].length > 1 && options[:delayed_output]
+                  output << { event: event, errors: errors }
+                else
+                  emit_events(event, *errors, region: cloud.cloudfile.region)
+                end
+                semaphore.synchronize { @errors = errors.any? if errors }
+              end
+              if options[:cloudfiles].length > 1 && options[:delayed_output]
+                semaphore.synchronize { outputs << { cloud_name: cloud.cloudfile.name, region: cloud.cloudfile.region, logging: output } }
+              end
+            end
+          end
+        end
+        workers.each(&:join)
+        print_outputs(outputs) if outputs && outputs.any?
       end
 
       def emit_events(event, *errors, region: nil)
@@ -169,12 +146,17 @@ module Convection
       def print_outputs(outputs)
         outputs.each do |output|
           puts '********'
-          puts output[:region]
+          puts "Cloud name: #{output[:cloud_name]}. Region: #{output[:region]}."
           puts '********'
           output[:logging].each do |hash|
             emit_events(hash[:event], *hash[:errors])
           end
         end
+      end
+
+      def init_cloud
+        @cloud = Control::Cloud.new
+        @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
       end
     end
   end

--- a/bin/convection
+++ b/bin/convection
@@ -22,7 +22,9 @@ module Convection
     option :cloudfiles, :type => :array, :default => %w(Cloudfile)
     option :delayed_output, :type => :boolean, :desc => 'Delay output until operation completion.', :default => true
     def converge(stack = nil)
-      task('converge', stack)
+      @outputs = []
+      operation('converge', stack)
+      print_outputs(@outputs) if @outputs && @outputs.any?
       exit 1 if @errors
     end
 
@@ -58,7 +60,9 @@ module Convection
     option :cloudfiles, :type => :array, :default => %w(Cloudfile)
     option :delayed_output, :type => :boolean, :desc => 'Delay output until operation completion.', :default => true
     def diff(stack = nil)
-      task('diff', stack)
+      @outputs = []
+      operation('diff', stack)
+      print_outputs(@outputs) if @outputs && @outputs.any?
       exit 1 if @errors
     end
 
@@ -81,12 +85,12 @@ module Convection
 
       private
 
-      def task(task_name, stack)
-        outputs = []
+      def operation(task_name, stack)
         work_q = Queue.new
         semaphore = Mutex.new
         if options[:delayed_output]
-          puts 'For easier reading when using multiple cloudfiles output will be delayed until task completion. If you would like immediate output please use the "--delayed_output false" option.'.red
+          puts 'For easier reading when using multiple cloudfiles output will be delayed until task completion.'.red
+          puts 'If you would like immediate output please use the "--delayed_output false" option.'.red
         end
         options[:cloudfiles].each { |cloudfile| work_q.push(cloud: Control::Cloud.new, cloudfile_path: cloudfile) }
         workers = (0...options[:cloudfiles].length).map do
@@ -105,13 +109,12 @@ module Convection
                 semaphore.synchronize { @errors = errors.any? if errors }
               end
               if options[:cloudfiles].length > 1 && options[:delayed_output]
-                semaphore.synchronize { outputs << { cloud_name: cloud.cloudfile.name, region: cloud.cloudfile.region, logging: output } }
+                semaphore.synchronize { @outputs << { cloud_name: cloud.cloudfile.name, region: cloud.cloudfile.region, logging: output } }
               end
             end
           end
         end
         workers.each(&:join)
-        print_outputs(outputs) if outputs && outputs.any?
       end
 
       def emit_events(event, *errors, region: nil)

--- a/bin/convection
+++ b/bin/convection
@@ -65,43 +65,49 @@ module Convection
     option :stack_group, :type => :string, :desc => 'The name of a stack group defined in your cloudfile to diff'
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to diff'
     def diff(stack = nil)
-      time = Benchmark.realtime do
+      outputs = []
       semaphore = Mutex.new
       work_q = Queue.new
       options[:cloudfiles].each {|cloudfile| work_q.push({cloud: Control::Cloud.new, cloudfile_path: cloudfile}) }
       workers = (0...options[:cloudfiles].length).map do
         Thread.new do
           until work_q.empty?
+            output = []
             cloud_array = work_q.pop(true)
             cloud_array[:cloud].configure(File.absolute_path(cloud_array[:cloudfile_path], @cwd))
             last_event = nil
             cloud = cloud_array[:cloud]
             cloud.diff(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |d|
-              semaphore.synchronize {
               if d.is_a? Model::Event
                 if options[:'very-verbose'] || d.name == :error
-                  say_status(*d.to_thor)
+                  output << d
                 elsif options[:verbose]
-                  say_status(*d.to_thor) if d.name == :compare
+                  output << d if d.name == :compare
                 end
                 last_event = d
               elsif d.is_a? Model::Diff
                 if !options[:'very-verbose'] && !options[:verbose]
-                  say_status(*last_event.to_thor) unless last_event.nil?
+                  output << last_event unless last_event.nil?
                   last_event = nil
                 end
-                say_status(*d.to_thor)
+                output << d
               else
-                say_status(*d.to_thor)
+                output << d
               end
-              }
             end
+            semaphore.synchronize {
+              outputs << {region: cloud.cloudfile.region, logging: output}
+            }
           end
         end
       end
       workers.each(&:join)
+      outputs.each do |output|
+        puts output[:region]
+        output[:logging].each do |status|
+          say_status(*status.to_thor)
+        end
       end
-      puts "Diff time = #{time*1000} ms"
     end
 
     desc 'print STACK', 'Print the rendered template for STACK'

--- a/bin/convection
+++ b/bin/convection
@@ -38,7 +38,7 @@ module Convection
               if options[:cloudfiles].length > 1 && options[:delayed_output]
                 output <<  {event: event, errors: errors}
               else
-                emit_events(event, *errors, cloud.cloudfile.region)
+                emit_events(event, *errors, region: cloud.cloudfile.region)
               end
               semaphore.synchronize {
                 if @errors == false && errors
@@ -104,7 +104,7 @@ module Convection
               if options[:cloudfiles].length > 1 && options[:delayed_output]
                 output <<  {event: event, errors: errors}
               else
-                emit_events(event, *errors, cloud.cloudfile.region)
+                emit_events(event, *errors, region: cloud.cloudfile.region)
               end
               semaphore.synchronize {
                 if @errors == false && errors
@@ -145,23 +145,22 @@ module Convection
       end
 
 
-      def emit_events(event, *errors, region)
-        #event.region = region
+      def emit_events(event, *errors, region: nil)
         if event.is_a? Model::Event
           if options[:'very-verbose'] || event.name == :error
-            print_info(event, region)
+            print_info(event, region: region)
           elsif options[:verbose]
-            print_info(event, region) if event.name == :compare
+            print_info(event, region: region) if event.name == :compare
           end
           @last_event = event
         elsif event.is_a? Model::Diff
           if !options[:'very-verbose'] && !options[:verbose]
-            print_info(last_event, region) unless last_event.nil?
+            print_info(last_event, region: region) unless last_event.nil?
             @last_event = nil
           end
-          print_info(event, region)
+          print_info(event, region: region)
         else
-          print_info(event, region)
+          print_info(event, region: region)
         end
 
         errors.each do |error|
@@ -170,8 +169,8 @@ module Convection
         end
       end
 
-      def print_info(say, region = nil)
-        print "#{region} "
+      def print_info(say, region: nil)
+        print "#{region} " if region
         say_status(*say.to_thor)
       end
 
@@ -181,7 +180,7 @@ module Convection
           puts output[:region]
           puts "********"
           output[:logging].each do |hash|
-            emit_events(hash[:event], *hash[:errors], nil)
+            emit_events(hash[:event], *hash[:errors])
           end
         end
       end

--- a/bin/convection
+++ b/bin/convection
@@ -19,6 +19,7 @@ module Convection
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to converge'
     option :cloudfiles, :type => :array, :default => %w(Cloudfile)
     def converge(stack = nil)
+      error_count = 0
       outputs = []
       semaphore = Mutex.new
       work_q = Queue.new
@@ -31,28 +32,24 @@ module Convection
             cloud_array[:cloud].configure(File.absolute_path(cloud_array[:cloudfile_path], @cwd))
             cloud = cloud_array[:cloud]
             cloud.converge(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|
-              output <<  {event: event, errors: errors}
+              if options[:cloudfiles].length > 1
+                output <<  {event: event, errors: errors}
+              else
+                error_count += converge_output(event,errors)
+              end
             end
-            semaphore.synchronize {
-              outputs << {region: cloud.cloudfile.region, logging: output}
-            }
+            semaphore.synchronize { outputs << {region: cloud.cloudfile.region, logging: output} } if options[:cloudfiles].length > 1
           end
         end
 
       end
       workers.each(&:join)
-      error_count = 0
       outputs.each do |output|
         puts "********"
         puts output[:region]
         puts "********"
         output[:logging].each do |hash|
-          say_status(*hash[:event].to_thor)
-          hash[:errors].each do |error|
-            error_count +=1
-          say "* #{ error.message }"
-          error.backtrace.each { |b| say "    #{ b }" }
-          end unless hash[:errors].nil?
+          error_count += converge_output(hash[:event], hash[:errors])
         end
       end
       if error_count > 0
@@ -161,6 +158,16 @@ module Convection
     no_commands do
       def init_cloud
         @cloud = Control::Cloud.new
+      end
+
+      def converge_output(event, errors)
+        say_status(*event.to_thor)
+        errors.each do |error|
+          say "* #{ error.message }"
+          error.backtrace.each { |b| say "    #{ b }" }
+        end unless errors.nil?
+        return errors.length unless errors.nil?
+        return 0
       end
     end
   end

--- a/bin/convection
+++ b/bin/convection
@@ -9,17 +9,15 @@ module Convection
   # Convection CLI
   ##
   class CLI < Thor
-    class_option :cloudfile, :type => :string, :default => 'Cloudfile'
-    class_option :cloudfiles, :type => :array
     def initialize(*args)
       super
-      #@cloud = Control::Cloud.new
       @cwd = Dir.getwd
     end
 
     desc 'converge STACK', 'Converge your cloud'
     option :stack_group, :type => :string, :desc => 'The name of a stack group defined in your cloudfile to converge'
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to converge'
+    option :cloudfiles, :type => :array, :default => %w(Cloudfile)
     def converge(stack = nil)
       semaphore = Mutex.new
       work_q = Queue.new
@@ -48,7 +46,9 @@ module Convection
     desc 'delete STACK', 'Delete stack(s) from your cloud'
     option :stack_group, :type => :string, :desc => 'The name of a stack group defined in your cloudfile to delete'
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to delete'
+    option :cloudfile, :type => :string, :default => 'Cloudfile'
     def delete(stack = nil)
+      init_cloud
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
       print_status = lambda do |event, *errors|
         say_status(*event.to_thor)
@@ -78,6 +78,7 @@ module Convection
     option :'very-verbose', :type => :boolean, :aliases => '--vv', :desc => 'Show unchanged stacks'
     option :stack_group, :type => :string, :desc => 'The name of a stack group defined in your cloudfile to diff'
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to diff'
+    option :cloudfiles, :type => :array, :default => %w(Cloudfile)
     def diff(stack = nil)
       outputs = []
       semaphore = Mutex.new
@@ -126,14 +127,22 @@ module Convection
 
     desc 'print STACK', 'Print the rendered template for STACK'
     def print(stack)
+      init_cloud
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
       puts @cloud.stacks[stack].to_json(true)
     end
 
     desc 'validate STACK', 'Validate the rendered template for STACK'
     def validate(stack)
+      init_cloud
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
       @cloud.stacks[stack].validate
+    end
+
+    no_commands do
+      def init_cloud
+        @cloud = Control::Cloud.new
+      end
     end
   end
 end

--- a/bin/convection
+++ b/bin/convection
@@ -103,10 +103,10 @@ module Convection
             cloud_array[:cloud].configure(File.absolute_path(cloud_array[:cloudfile_path], @cwd))
             cloud = cloud_array[:cloud]
             cloud.diff(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|
-              if options[:cloudfiles].length > 1
+              if options[:cloudfiles].length > 1 &&
                 output <<  {event: event, errors: errors}
               else
-                emit_events(event, *errors)
+                emit_events(event, *errors, cloud.cloudfile.region)
               end
             end
             semaphore.synchronize { outputs << {region: cloud.cloudfile.region, logging: output} } if options[:cloudfiles].length > 1
@@ -125,8 +125,8 @@ module Convection
       end
     end
 
-    desc 'print STACK', 'Print the rendered template for STACK'
-    def print(stack)
+    desc 'print_template STACK', 'Print the rendered template for STACK'
+    def print_template(stack)
       init_cloud
       @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
       puts @cloud.stacks[stack].to_json(true)
@@ -149,29 +149,34 @@ module Convection
       end
 
 
-      def emit_events(event, *errors)
+      def emit_events(event, *errors, region)
         #event.region = region
         if event.is_a? Model::Event
           if options[:'very-verbose'] || event.name == :error
-            say_status(*event.to_thor)
+            print_output(event, region)
           elsif options[:verbose]
-            say_status(*event.to_thor) if event.name == :compare
+            print_output(event, region) if event.name == :compare
           end
           @last_event = event
         elsif event.is_a? Model::Diff
           if !options[:'very-verbose'] && !options[:verbose]
-            say_status(*last_event.to_thor) unless last_event.nil?
+            print_output(last_event, region) unless last_event.nil?
             @last_event = nil
           end
-          say_status(*event.to_thor)
+          print_output(event, region)
         else
-          say_status(*event.to_thor)
+          print_output(event, region)
         end
 
         errors.each do |error|
           say "* #{ error.message }"
           error.backtrace.each { |trace| say "    #{ trace }" }
         end
+      end
+
+      def print_output(say, region = nil)
+        print region
+        say_status(*say.to_thor)
       end
     end
   end

--- a/bin/convection
+++ b/bin/convection
@@ -12,6 +12,7 @@ module Convection
     def initialize(*args)
       super
       @cwd = Dir.getwd
+      @errors = false
     end
 
     desc 'converge STACK', 'Converge your cloud'
@@ -20,8 +21,8 @@ module Convection
     option :verbose, :type => :boolean, :aliases => '--v', :desc => 'Show stack progress', default: true
     option :'very-verbose', :type => :boolean, :aliases => '--vv', :desc => 'Show unchanged stacks', default: true
     option :cloudfiles, :type => :array, :default => %w(Cloudfile)
+    option :delayed_output, :type => :boolean, :desc => 'Delay output until operation completion. Makes output easier to read if operating on multiple cloudfiles', :default => true
     def converge(stack = nil)
-      error_count = 0
       outputs = []
       semaphore = Mutex.new
       work_q = Queue.new
@@ -34,29 +35,25 @@ module Convection
             cloud_array[:cloud].configure(File.absolute_path(cloud_array[:cloudfile_path], @cwd))
             cloud = cloud_array[:cloud]
             cloud.converge(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|
-              if options[:cloudfiles].length > 1
+              if options[:cloudfiles].length > 1 && options[:delayed_output]
                 output <<  {event: event, errors: errors}
               else
-                emit_events(event, *errors)
+                emit_events(event, *errors, cloud.cloudfile.region)
               end
-
+              semaphore.synchronize {
+                if @errors == false && errors
+                  @errors = true
+                end
+              }
             end
-
-            semaphore.synchronize { outputs << {region: cloud.cloudfile.region, logging: output} } if options[:cloudfiles].length > 1
+            semaphore.synchronize { outputs << {region: cloud.cloudfile.region, logging: output} } if options[:cloudfiles].length > 1 && options[:delayed_output]
           end
         end
 
       end
       workers.each(&:join)
-
-      outputs.each do |output|
-        puts "********"
-        puts output[:region]
-        puts "********"
-        output[:logging].each do |hash|
-         emit_events(hash[:event], *hash[:errors])
-        end
-      end
+      print_outputs(outputs) if outputs.length > 0
+      exit 1 if @errors
     end
 
     desc 'delete STACK', 'Delete stack(s) from your cloud'
@@ -90,6 +87,7 @@ module Convection
     option :verbose, :type => :boolean, :aliases => '--v', :desc => 'Show stack progress'
     option :'very-verbose', :type => :boolean, :aliases => '--vv', :desc => 'Show unchanged stacks'
     option :cloudfiles, :type => :array, :default => %w(Cloudfile)
+    option :delayed_output, :type => :boolean, :desc => 'Delay output until operation completion. Makes output easier to read if operating on multiple cloudfiles', :default => true
     def diff(stack = nil)
       outputs = []
       semaphore = Mutex.new
@@ -103,26 +101,24 @@ module Convection
             cloud_array[:cloud].configure(File.absolute_path(cloud_array[:cloudfile_path], @cwd))
             cloud = cloud_array[:cloud]
             cloud.diff(stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|
-              if options[:cloudfiles].length > 1 &&
+              if options[:cloudfiles].length > 1 && options[:delayed_output]
                 output <<  {event: event, errors: errors}
               else
                 emit_events(event, *errors, cloud.cloudfile.region)
               end
+              semaphore.synchronize {
+                if @errors == false && errors
+                  @errors = true
+                end
+              }
             end
-            semaphore.synchronize { outputs << {region: cloud.cloudfile.region, logging: output} } if options[:cloudfiles].length > 1
+            semaphore.synchronize { outputs << {region: cloud.cloudfile.region, logging: output} } if options[:cloudfiles].length > 1 && options[:delayed_output]
           end
         end
       end
-
       workers.each(&:join)
-      outputs.each do |output|
-        puts "********"
-        puts output[:region]
-        puts "********"
-        output[:logging].each do |hash|
-          emit_events(hash[:event], *hash[:errors])
-        end
-      end
+      print_outputs(outputs) if outputs.length > 0
+      exit 1 if @errors
     end
 
     desc 'print_template STACK', 'Print the rendered template for STACK'
@@ -153,19 +149,19 @@ module Convection
         #event.region = region
         if event.is_a? Model::Event
           if options[:'very-verbose'] || event.name == :error
-            print_output(event, region)
+            print_info(event, region)
           elsif options[:verbose]
-            print_output(event, region) if event.name == :compare
+            print_info(event, region) if event.name == :compare
           end
           @last_event = event
         elsif event.is_a? Model::Diff
           if !options[:'very-verbose'] && !options[:verbose]
-            print_output(last_event, region) unless last_event.nil?
+            print_info(last_event, region) unless last_event.nil?
             @last_event = nil
           end
-          print_output(event, region)
+          print_info(event, region)
         else
-          print_output(event, region)
+          print_info(event, region)
         end
 
         errors.each do |error|
@@ -174,9 +170,20 @@ module Convection
         end
       end
 
-      def print_output(say, region = nil)
-        print region
+      def print_info(say, region = nil)
+        print "#{region} "
         say_status(*say.to_thor)
+      end
+
+      def print_outputs(outputs)
+        outputs.each do |output|
+          puts "********"
+          puts output[:region]
+          puts "********"
+          output[:logging].each do |hash|
+            emit_events(hash[:event], *hash[:errors], nil)
+          end
+        end
       end
     end
   end

--- a/bin/convection
+++ b/bin/convection
@@ -38,7 +38,7 @@ module Convection
               else
                 emit_events(event, *errors, region: cloud.cloudfile.region)
               end
-              semaphore.synchronize { @errors = true if @errors == false && errors }
+              semaphore.synchronize { @errors = errors.any? }
             end
             if options[:cloudfiles].length > 1 && options[:delayed_output]
               semaphore.synchronize { outputs << { region: cloud.cloudfile.region, logging: output } }
@@ -47,7 +47,7 @@ module Convection
         end
       end
       workers.each(&:join)
-      print_outputs(outputs) unless outputs.empty?
+      print_outputs(outputs) if outputs.any?
       exit 1 if @errors
     end
 
@@ -59,7 +59,6 @@ module Convection
     option :'very-verbose', :type => :boolean, :aliases => '--vv', :desc => 'Show unchanged stacks', default: true
     def delete(stack = nil)
       init_cloud
-      @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
 
       stacks = @cloud.stacks_until(stack, options, &method(:emit_events))
       if stacks.empty?
@@ -101,7 +100,7 @@ module Convection
               else
                 emit_events(event, *errors, region: cloud.cloudfile.region)
               end
-              semaphore.synchronize { @errors = true if @errors == false && errors }
+              semaphore.synchronize { @errors = errors.any? }
             end
             if options[:cloudfiles].length > 1 && options[:delayed_output]
               semaphore.synchronize { outputs << { region: cloud.cloudfile.region, logging: output } }
@@ -110,21 +109,21 @@ module Convection
         end
       end
       workers.each(&:join)
-      print_outputs(outputs) unless outputs.empty?
+      print_outputs(outputs) if outputs.any?
       exit 1 if @errors
     end
 
     desc 'print_template STACK', 'Print the rendered template for STACK'
+    option :cloudfile, :type => :string, :default => 'Cloudfile'
     def print_template(stack)
       init_cloud
-      @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
       puts @cloud.stacks[stack].to_json(true)
     end
 
     desc 'validate STACK', 'Validate the rendered template for STACK'
+    option :cloudfile, :type => :string, :default => 'Cloudfile'
     def validate(stack)
       init_cloud
-      @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
       @cloud.stacks[stack].validate
     end
 
@@ -135,6 +134,7 @@ module Convection
 
       def init_cloud
         @cloud = Control::Cloud.new
+        @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
       end
 
       def emit_events(event, *errors, region: nil)

--- a/bin/convection
+++ b/bin/convection
@@ -117,16 +117,17 @@ module Convection
               cloud_array = work_q.pop(true)
               cloud_array[:cloud].configure(File.absolute_path(cloud_array[:cloudfile_path], @cwd))
               cloud = cloud_array[:cloud]
+              region = cloud.cloudfile.region
               cloud.send(task_name, stack, stack_group: options[:stack_group], stacks: options[:stacks]) do |event, errors|
                 if options[:cloudfiles].length > 1 && options[:delayed_output]
                   output << { event: event, errors: errors }
                 else
-                  emit_events(event, *errors, region: cloud.cloudfile.region)
+                  emit_events(event, *errors, region: region)
                 end
                 semaphore.synchronize { @errors = errors.any? if errors }
               end
               if options[:cloudfiles].length > 1 && options[:delayed_output]
-                semaphore.synchronize { @outputs << { cloud_name: cloud.cloudfile.name, region: cloud.cloudfile.region, logging: output } }
+                semaphore.synchronize { @outputs << { cloud_name: cloud.cloudfile.name, region: region, logging: output } }
               end
             end
           end

--- a/bin/convection
+++ b/bin/convection
@@ -2,7 +2,6 @@
 require 'thor'
 require_relative '../lib/convection/control/cloud'
 require 'thread'
-require 'colorize'
 module Convection
   ##
   # Convection CLI
@@ -122,7 +121,7 @@ module Convection
                 if options[:cloudfiles].length > 1 && options[:delayed_output]
                   output << { event: event, errors: errors }
                 else
-                  emit_events(event, *errors)
+                  emit_events(event, *errors, region: cloud.cloudfile.region)
                 end
                 semaphore.synchronize { @errors = errors.any? if errors }
               end

--- a/convection.gemspec
+++ b/convection.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'httparty', '~> 0.13'
   spec.add_runtime_dependency 'netaddr', '~> 1.5'
   spec.add_runtime_dependency 'thor', '~> 0.19'
+  spec.add_runtime_dependency 'colorize'
 end

--- a/convection.gemspec
+++ b/convection.gemspec
@@ -22,5 +22,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'httparty', '~> 0.13'
   spec.add_runtime_dependency 'netaddr', '~> 1.5'
   spec.add_runtime_dependency 'thor', '~> 0.19'
-  spec.add_runtime_dependency 'colorize'
 end

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -202,11 +202,11 @@ compare  Compare local state of stack vpc (convection-demo-vpc) with remote temp
  create  .Resources.DemoVPC.Properties.Tags.0.Key: Name
  create  .Resources.DemoVPC.Properties.Tags.0.Value: convection-demo-vpc
 ```
-To see what the cloud formation template for your vpc template would look like you can run `convection print vpc`.
+To see what the cloud formation template for your vpc template would look like you can run `convection print_template vpc`.
 This can help you verify that values referenced under the `stack` namespace are set correctly.
 
 ```json
-$> convection print vpc
+$> convection print_template vpc
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "VPC with Public and Private Subnets (NAT)",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -206,7 +206,7 @@ To see what the cloud formation template for your vpc template would look like y
 This can help you verify that values referenced under the `stack` namespace are set correctly.
 
 ```json
-$> convection print_template vpc
+$> convection print-template vpc
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "VPC with Public and Private Subnets (NAT)",

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ Or install it yourself as:
 - To print out a list of available cli options with their descriptions run `convection help`.
 
 ###### Print
-- To print out the cloud formation template for a specific stack run `convection print_template my-stack-name`.
+- To print out the cloud formation template for a specific stack run `convection print-template my-stack-name`.
 
 ###### Validate
 - To validate your stack is not missing a required resource run `convection validate my-stack-name`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,9 +23,10 @@ Or install it yourself as:
 
 ##CLI Commands
 ###### Converging
-- To converge all stacks in your cloudfile run `convection converge`. If you provide the name of your stack as a additional argument such as `convection converge my-stack-name` then all stacks above and including the stack you specified will be converged.
+- To converge all stacks in your cloudfile run `convection converge` in the same directory as your cloudfile or use `--cloudfiles` and specify the path to the cloudfile. If you provide the name of your stack as a additional argument such as `convection converge my-stack-name` then all stacks above and including the stack you specified will be converged.
 - To converge a stack group run `convection converge --stack_group YOUR_STACK_GROUP_NAME`
 - To converge a specific stack or a list of stacks run `convection converge --stacks stackA stackB ...`
+- To converge multiple cloudfiles at the same time run use the `--cloudfiles`  option providing the path to the cloudfiles. Example `bundle exec convection converge --cloudfiles us-east-1/Cloudfile eu-central-1/Cloudfile`
 
 ###### Diff
 - To display a diff between your local changes and the version of your stack in cloud formation of your changes run `convection diff`.
@@ -36,7 +37,7 @@ Or install it yourself as:
 - To print out a list of available cli options with their descriptions run `convection help`.
 
 ###### Print
-- To print out the cloud formation template for a specific stack run `convection print my-stack-name`.
+- To print out the cloud formation template for a specific stack run `convection print_template my-stack-name`.
 
 ###### Validate
 - To validate your stack is not missing a required resource run `convection validate my-stack-name`.

--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -7,6 +7,7 @@ module Convection
     # Control tour Clouds
     ##
     class Cloud
+      attr_accessor :cloudfile
       def configure(cloudfile)
         @cloudfile = Model::Cloudfile.new(cloudfile)
       end


### PR DESCRIPTION
<!-- Remove any sections that do not apply to your changes. HTML comments are ignored. -->
# Description
Fix #203 - This adds the ability to converge or diff multiple cloudfiles at the same time.

# Motivation and Context
Aids in deploying to multiple regions.
# Usage Examples
```
bundle exec convection diff --cloudfiles us-east-1/Cloudfile eu-central-1/Cloudfile
bundle exec convection converge --cloudfiles us-east-1/Cloudfile eu-central-1/Cloudfile
```
# Testing Steps
- [x] Diffs work with one cloudfile
- [x] Diffs work with two cloudfiles
- [x] Converges work with one cloudfile
- [x] Converges work with two cloudfiles
- [x] Converge/diff will check the current working directory for a cloudfile
- [x] Delayed output "true" will print output upon task completion
- [x] Delayed output "false" will print output immediately 

# Remaining Tasks
- [x] Update docs with new converge/diff examples
- [x] Update docs around stack print changes