### PR TITLE
Fix #212 - Specify --cloudfile for task subcommands

### DIFF
--- a/bin/convection
+++ b/bin/convection
@@ -76,8 +76,7 @@ module Convection
     option :cloudfile, :type => :string, :default => 'Cloudfile'
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to diff', default: []
     def describe_tasks
-      @cloud = Control::Cloud.new
-      @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
+      init_cloud
 
       describe_stack_tasks(options[:stacks])
     end
@@ -86,8 +85,7 @@ module Convection
     option :cloudfile, :type => :string, :default => 'Cloudfile'
     option :stack, :desc => 'The stack to run tasks for', :required => true
     def run_tasks
-      @cloud = Control::Cloud.new
-      @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
+      init_cloud
 
       run_stack_tasks(options[:stack])
     end
@@ -221,6 +219,11 @@ module Convection
       end
 
       def init_cloud
+        if options['cloudfile'].nil?
+          warn 'ERROR: The you must specify the --cloudfile option.'
+          exit 1
+        end
+
         @cloud = Control::Cloud.new
         @cloud.configure(File.absolute_path(options['cloudfile'], @cwd))
       end

--- a/bin/convection
+++ b/bin/convection
@@ -73,6 +73,7 @@ module Convection
     end
 
     desc 'describe-tasks [--stacks STACKS]', 'Describe tasks for a given stack'
+    option :cloudfile, :type => :string, :default => 'Cloudfile'
     option :stacks, :type => :array, :desc => 'A ordered space separated list of stacks to diff', default: []
     def describe_tasks
       @cloud = Control::Cloud.new
@@ -82,6 +83,7 @@ module Convection
     end
 
     desc 'run-tasks [--stack STACK]', 'Run tasks for a given stack'
+    option :cloudfile, :type => :string, :default => 'Cloudfile'
     option :stack, :desc => 'The stack to run tasks for', :required => true
     def run_tasks
       @cloud = Control::Cloud.new


### PR DESCRIPTION
# Description
Fix #212.

Specify the `:cloudfile` thor method option to all task subcommands vs. depending on the obsoleted thor class option.