### PR TITLE
Add S3 Website Configuration and properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ attic
 
 *.swp
 *.swo
+*.gem

--- a/lib/convection/model/template/resource/aws_s3_bucket.rb
+++ b/lib/convection/model/template/resource/aws_s3_bucket.rb
@@ -25,6 +25,7 @@ module Convection
           property :notification_configuration, 'NotificationConfiguration'
           property :replication_configuration, 'ReplicationConfiguration'
           property :versioning_configuration, 'VersioningConfiguration'
+          property :website_configuration, 'WebsiteConfiguration'
 
           def cors_configuration(&block)
             config = ResourceProperty::S3CorsConfiguration.new(self)
@@ -41,6 +42,12 @@ module Convection
             config = ResourceProperty::S3ReplicationConfiguration.new(self)
             config.instance_exec(&block) if block
             properties['ReplicationConfiguration'].set(config)
+          end
+
+          def website_configuration(&block)
+            config = ResourceProperty::S3WebsiteConfiguration.new(self)
+            config.instance_exec(&block) if block
+            properties['WebsiteConfiguration'].set(config)
           end
 
           def render(*args)

--- a/lib/convection/model/template/resource_property/aws_cloudfront_defaultcachebehavior.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_defaultcachebehavior.rb
@@ -12,6 +12,7 @@ module Convection
           property :compress, 'Compress'
           property :default_ttl, 'DefaultTTL'
           property :forwarded_values, 'ForwardedValues'
+          property :max_ttl, 'MaxTTL'
           property :min_ttl, 'MinTTL'
           property :smooth_streaming, 'SmoothStreaming'
           property :target_origin, 'TargetOriginId'

--- a/lib/convection/model/template/resource_property/aws_s3_website_configuration.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_website_configuration.rb
@@ -1,0 +1,30 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration.html
+        # Amazon S3 Website Configuration}
+        class S3WebsiteConfiguration < ResourceProperty
+          property :error_document, 'ErrorDocument'
+          property :index_document, 'IndexDocument'
+          property :redirect_all_reqs_to, 'RedirectAllRequestsTo'
+          property :routing_rules, 'RoutingRules', :type => :list
+
+          def redirect_all_requests_to(&block)
+            redirect_to = ResourceProperty::S3WebsiteConfigurationRedirectAllRequestsTo.new(self)
+            redirect_to.instance_exec(&block) if block
+            properties['RedirectAllRequestsTo'].set(redirect_to)
+          end
+
+          def routing_rule(&block)
+            routing_rule = ResourceProperty::S3WebsiteConfigurationRoutingRule.new(self)
+            routing_rule.instance_exec(&block) if block
+            routing_rules << routing_rule
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_website_configuration_redirect_all_requests_to.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_website_configuration_redirect_all_requests_to.rb
@@ -1,0 +1,16 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-redirectallrequeststo.html
+        # Amazon S3 Website Configuration Redirect All Requests To}
+        class S3WebsiteConfigurationRedirectAllRequestsTo < ResourceProperty
+          property :host_name, 'HostName'
+          property :protocol, 'Protocol'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_website_configuration_routing_rule.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_website_configuration_routing_rule.rb
@@ -1,0 +1,28 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules.html
+        # Amazon S3 Website Configuration Routing Rule}
+        class S3WebsiteConfigurationRoutingRule < ResourceProperty
+          property :redirect_rul, 'RedirectRule'
+          property :routing_rule_cond, 'RoutingRuleCondition'
+
+          def redirect_rule(&block)
+            redr = ResourceProperty::S3WebsiteConfigurationRoutingRuleRedirectRule.new(self)
+            redr.instance_exec(&block) if block
+            properties['RedirectRule'].set(redr)
+          end
+
+          def routing_rule_condition(&block)
+            cond = ResourceProperty::S3WebsiteConfigurationRoutingRuleRoutingRuleCondition.new(self)
+            cond.instance_exec(&block) if block
+            properties['RoutingRuleCondition'].set(cond)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_website_configuration_routing_rule_redirect_rule.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_website_configuration_routing_rule_redirect_rule.rb
@@ -1,0 +1,19 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules-redirectrule.html
+        # Amazon S3 Website Configuration Routing Rule Redirect Rule}
+        class S3WebsiteConfigurationRoutingRuleRedirectRule < ResourceProperty
+          property :host_name, 'HostName'
+          property :http_redirect_code, 'HttpRedirectCode'
+          property :protocol, 'Protocol'
+          property :replace_key_prefix_with, 'ReplaceKeyPrefixWith'
+          property :replace_key_with, 'ReplaceKeyWith'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_s3_website_configuration_routing_rule_routing_rule_condition.rb
+++ b/lib/convection/model/template/resource_property/aws_s3_website_configuration_routing_rule_routing_rule_condition.rb
@@ -1,0 +1,16 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules-routingrulecondition.html
+        # Amazon S3 Website Configuration Routing Rule Routing Rule Condition}
+        class S3WebsiteConfigurationRoutingRule < ResourceProperty
+          property :http_error_code_returned_equals, 'HttpErrorCodeReturnedEquals'
+          property :key_prefix_equals, 'KeyPrefixEquals'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Remove any sections that do not apply to your changes. HTML comments are ignored. -->
# Description
Add ability to specify a website_configuration to an s3 bucket.  To do correctly, this required creating a number of resource_property types to support the various options that CloudFormation gives.
<!-- Describe your changes here. -->
<!-- Include references to relevant pull requests/commits here. -->
<!-- * Did you update documentation? -->
<!-- * Did you update test coverage? -->

# Motivation and Context
This change is necessary to enable static website hosting for an s3 bucket.
<!-- Describe the use case that requires your changes. -->

# Usage Examples
<!-- Code or screenshot examples of using your feature, if applicable. -->
    s3_bucket 'bucketName' do
      ...
      website_configuration do
        index_document 'index.html'
        redirect_all_requests_to do
          host_name 'somehost.example.com'
          protocol 'https'
        end
      end
    end

# Testing Steps
<!-- List any steps required to test your changes. -->

# Post-merge Steps
<!-- List any steps required after merging your changes. -->

