### PR TITLE
Maintain backwards compatability with route53

### DIFF
--- a/lib/convection/model/template/resource/aws_route53_recordset.rb
+++ b/lib/convection/model/template/resource/aws_route53_recordset.rb
@@ -26,16 +26,28 @@ module Convection
           property :record_type, 'Type'
           property :weight, 'Weight'
 
+          # Add new resource_property functionality
           def alias_target(&block)
             a = ResourceProperty::Route53AliasTarget.new(self)
             a.instance_exec(&block) if block
             properties['AliasTarget'].set(a)
           end
 
+          # Maintain backwards compatability
+          def alias_target(obj)
+            alias_tgt obj
+          end
+
+          # Add new resource_property functionality
           def geo_location(&block)
             g = ResourceProperty::Route53GeoLocation.new(self)
             g.instance_exec(&block) if block
             properties['GeoLocation'].set(g)
+          end
+
+          # Maintain backwards compatability
+          def geo_location(obj)
+            geo_loc obj
           end
         end
       end

--- a/lib/convection/model/template/resource/aws_route53_recordset.rb
+++ b/lib/convection/model/template/resource/aws_route53_recordset.rb
@@ -49,7 +49,6 @@ module Convection
               properties['GeoLocation'].set(g)
             end
           end
-
         end
       end
     end

--- a/lib/convection/model/template/resource/aws_route53_recordset.rb
+++ b/lib/convection/model/template/resource/aws_route53_recordset.rb
@@ -26,29 +26,30 @@ module Convection
           property :record_type, 'Type'
           property :weight, 'Weight'
 
-          # Add new resource_property functionality
-          def alias_target(&block)
-            a = ResourceProperty::Route53AliasTarget.new(self)
-            a.instance_exec(&block) if block
-            properties['AliasTarget'].set(a)
+          def alias_target(tgt = nil, &block)
+            if tgt
+              # Maintain backwards compatability
+              alias_tgt tgt
+            else
+              # Add new resource_property functionality
+              a = ResourceProperty::Route53AliasTarget.new(self)
+              a.instance_exec(&block) if block
+              properties['AliasTarget'].set(a)
+            end
           end
 
-          # Maintain backwards compatability
-          def alias_target(obj)
-            alias_tgt obj
+          def geo_location(geo = nil, &block)
+            if geo
+              # Maintain backwards compatability
+              geo_loc geo
+            else
+              # Add new resource_property functionality
+              g = ResourceProperty::Route53GeoLocation.new(self)
+              g.instance_exec(&block) if block
+              properties['GeoLocation'].set(g)
+            end
           end
 
-          # Add new resource_property functionality
-          def geo_location(&block)
-            g = ResourceProperty::Route53GeoLocation.new(self)
-            g.instance_exec(&block) if block
-            properties['GeoLocation'].set(g)
-          end
-
-          # Maintain backwards compatability
-          def geo_location(obj)
-            geo_loc obj
-          end
         end
       end
     end


### PR DESCRIPTION
<!-- Remove any sections that do not apply to your changes. HTML comments are ignored. -->
# Description
<!-- Describe your changes here. -->
<!-- Include references to relevant pull requests/commits here. -->
<!-- * Did you update documentation? -->
<!-- * Did you update test coverage? -->
Changes alias_target and geo_location in a route53_recordset to allow either json or a resource_property

# Motivation and Context
<!-- Describe the use case that requires your changes. -->
Previously, users needed to specify the json for alias_target and
geo_location for a route53_recordset.  In the add-alb branch, merged in
PR 214, this was changed in a backwards-incompatible way, requiring
anyone who had previously specified json to now specify a block for the
resource_property.  Now, either way is acceptable.

This is potentially a paradigm that can be used elsewhere, as there are
many places where a resource_property would be appropriate, but has not
existed and users have implemented the functionality directly with a
json (or ruby hash) object.  This will allow us to deprecate that method
in favor of the more clean resource_property approach, without breaking
everything in a 1.0 upgrade.

# Usage Examples
<!-- Code or screenshot examples of using your feature, if applicable. -->

# Testing Steps
<!-- List any steps required to test your changes. -->

# Post-merge Steps
<!-- List any steps required after merging your changes. -->
