### PR TITLE
Target group helpers

### DIFF
--- a/lib/convection/model/template/resource/aws_elbv2_target_group.rb
+++ b/lib/convection/model/template/resource/aws_elbv2_target_group.rb
@@ -28,9 +28,14 @@ module Convection
           property :vpc_id, 'VpcId'
 
           # Append an attribute to target_group_attributes
-          def target_group_attribute(&block)
+          def target_group_attribute(key=nil, value=nil, &block)
             attribute = ResourceProperty::ELBV2TargetGroupAttribute.new(self)
-            attribute.instance_exec(&block) if block
+            if key and value
+              attribute.key key
+              attribute.value value
+            else
+              attribute.instance_exec(&block) if block
+            end
             target_group_attributes << attribute
           end
 
@@ -42,10 +47,14 @@ module Convection
           end
           alias target_description target
 
-          def matcher(&block)
+          def matcher(http_code=nil, &block)
             m = ResourceProperty::ELBV2TargetGroupMatcher.new(self)
-            m.instance_exec(&block) if block
-            properties['Matcher'].set(m)
+            if http_code
+              m.http_code http_code
+            else
+              m.instance_exec(&block) if block
+            end
+            match m
           end
 
           def render(*args)

--- a/lib/convection/model/template/resource/aws_elbv2_target_group.rb
+++ b/lib/convection/model/template/resource/aws_elbv2_target_group.rb
@@ -28,13 +28,13 @@ module Convection
           property :vpc_id, 'VpcId'
 
           # Append an attribute to target_group_attributes
-          def target_group_attribute(key=nil, value=nil, &block)
+          def target_group_attribute(key = nil, value = nil, &block)
             attribute = ResourceProperty::ELBV2TargetGroupAttribute.new(self)
-            if key and value
+            if key && value
               attribute.key key
               attribute.value value
-            else
-              attribute.instance_exec(&block) if block
+            elsif block
+              attribute.instance_exec(&block)
             end
             target_group_attributes << attribute
           end
@@ -47,12 +47,12 @@ module Convection
           end
           alias target_description target
 
-          def matcher(http_code=nil, &block)
+          def matcher(http_code = nil, &block)
             m = ResourceProperty::ELBV2TargetGroupMatcher.new(self)
             if http_code
               m.http_code http_code
-            else
-              m.instance_exec(&block) if block
+            elsif block
+              m.instance_exec(&block)
             end
             match m
           end


### PR DESCRIPTION
<!-- Remove any sections that do not apply to your changes. HTML comments are ignored. -->
# Description
<!-- Describe your changes here. -->
<!-- Include references to relevant pull requests/commits here. -->
<!-- * Did you update documentation? -->
<!-- * Did you update test coverage? -->
Adds the ability, suggested by @erran-r7 to specify target_group_attributes and matcher for an elbv2 target group.

# Motivation and Context
<!-- Describe the use case that requires your changes. -->

# Usage Examples
<!-- Code or screenshot examples of using your feature, if applicable. -->
Old way:

        matcher do
          http_code 200
        end
        target_group_attribute do
          key 'deregistration_delay.timeout_seconds'
          value 300
        end

New way:

        matcher 200
        target_group_attribute 'deregistration_delay.timeout_seconds', 300

# Testing Steps
<!-- List any steps required to test your changes. -->

# Post-merge Steps
<!-- List any steps required after merging your changes. -->

