### PR TITLE
Fix diff for Mappings

### DIFF
--- a/lib/convection/model/template.rb
+++ b/lib/convection/model/template.rb
@@ -186,7 +186,7 @@ module Convection
           if self[key].is_a?(Hash) || self[key].is_a?(Array)
             new_path = "#{path}#{path.empty? ? '' : '.'}#{key}"
             resource_type = self['Type']
-            new_path = "#{new_path}.#{resource_type}" if resource_type
+            new_path = "#{new_path}.#{resource_type}" if resource_type && !resource_type.empty?
             self[key].properties(memo, new_path)
           else
             memo["#{path}.#{key}"] = self[key]


### PR DESCRIPTION
<!-- Remove any sections that do not apply to your changes. HTML comments are ignored. -->
# Description
<!-- Describe your changes here. -->
<!-- Include references to relevant pull requests/commits here. -->
<!-- * Did you update documentation? -->
<!-- * Did you update test coverage? -->
Fixes the diff output for non-Resource parts of a CF template.

# Motivation and Context
<!-- Describe the use case that requires your changes. -->
The Mapings section of CloudFormation templates is treated the same way
by the diff flattener as the Resources section.  Unfortunately, when
updating the diff to be smart enough to know about updates which require
replacement, the Resource Type was added to the flattened key
unconditionally.  Since Mappings (and other not-Resources) have no
"Type" key, this meant an empty hash was added where the Type belonged.
To fix this, we now just don't put the Type in the flattened hash key
if there isn't one.