### PR TITLE
Fix #223 - Do not cast errors when diffing

### DIFF
--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -129,9 +129,7 @@ module Convection
           # Find errors during diff
           emit_credential_error_and_exit!(stack, &block) if stack.credential_error?
           if stack.error?
-            errors = stack.errors.collect { |x| x.exception.message }
-            errors = errors.uniq.flatten
-            block.call(Model::Event.new(:error, "Error diffing stack #{ stack.name} Error(s): #{errors.join(', ')}", :error), stack.errors) if block
+            block.call(Model::Event.new(:error, "Error diffing stack #{ stack.name }", :error), stack.errors) if block
             break
           end
 


### PR DESCRIPTION
Fix #223 — get rid of the undefined method error by removing cast to string.

Delete and converges stopped this when we updated error handling logic.