### PR TITLE
Add RoleName property to iam_role

### DIFF
--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -111,7 +111,7 @@ module Convection
         @tags = options.delete(:tags) { |_| {} } # Default empty hash
         options.delete(:disable_rollback) # There can be only one...
         @on_failure = options.delete(:on_failure) { |_| 'DELETE' }
-        @capabilities = options.delete(:capabilities) { |_| ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'] }
+        @capabilities = options.delete(:capabilities) { |_| %w(CAPABILITY_IAM CAPABILITY_NAMED_IAM) }
 
         @attributes = options.delete(:attributes) { |_| Model::Attributes.new }
         @options = options

--- a/lib/convection/control/stack.rb
+++ b/lib/convection/control/stack.rb
@@ -111,7 +111,7 @@ module Convection
         @tags = options.delete(:tags) { |_| {} } # Default empty hash
         options.delete(:disable_rollback) # There can be only one...
         @on_failure = options.delete(:on_failure) { |_| 'DELETE' }
-        @capabilities = options.delete(:capabilities) { |_| ['CAPABILITY_IAM'] }
+        @capabilities = options.delete(:capabilities) { |_| ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'] }
 
         @attributes = options.delete(:attributes) { |_| Model::Attributes.new }
         @options = options

--- a/lib/convection/model/template/resource/aws_iam_role.rb
+++ b/lib/convection/model/template/resource/aws_iam_role.rb
@@ -99,6 +99,7 @@ module Convection
           property :path, 'Path'
           property :policies, 'Policies', :type => :list
           property :managed_policy_arn, 'ManagedPolicyArns', :type => :list
+          property :role_name, 'RoleName'
           alias managed_policy managed_policy_arn
 
           attr_accessor :trust_relationship


### PR DESCRIPTION
# Description
The purpose of this is to enable creation of an IAM role with a
user-defined name.  Normally, when you tell CloudFormation to create a
role named "MyRole", it actually creates a role named
"mycloudname-MyRole-RANDOMCHARS".  This change allows a user to
explicitly create a role named "MyRole".
