### PR TITLE
Fix #223 - Cast string error messages to runtime error

### DIFF
--- a/bin/convection
+++ b/bin/convection
@@ -197,7 +197,8 @@ module Convection
         end
 
         errors.each do |error|
-          say "* #{ error.message }"
+          error = RuntimeError.new(error) if error.is_a?(String)
+          say "* #{ error_message }"
           error.backtrace.each { |trace| say "    #{ trace }" }
         end
       end


### PR DESCRIPTION
# Description
See also #223 and #224.

#224 didn't work since this is where the undefined method error is actually raised. The PR attempted fixing it at the source of input not where the call was made.