### PR TITLE
Fix #229 -- Return a list a availability zones

### DIFF
--- a/spec/convection/control/stack/after_create_tasks_spec.rb
+++ b/spec/convection/control/stack/after_create_tasks_spec.rb
@@ -38,7 +38,7 @@ module Convection::Control
       it 'is executed on Stack#apply' do
         subject.apply
 
-        expect(task.availability_zones).to include('eu-central-1')
+        expect(task.availability_zones).to include(a_string_starting_with('eu-central-1'))
       end
 
       it 'is deregistered after Stack#apply is called' do

--- a/spec/convection/control/stack/after_delete_tasks_spec.rb
+++ b/spec/convection/control/stack/after_delete_tasks_spec.rb
@@ -38,7 +38,7 @@ module Convection::Control
       it 'is executed on Stack#delete' do
         subject.delete
 
-        expect(task.availability_zones).to include('eu-central-1')
+        expect(task.availability_zones).to include(a_string_starting_with('eu-central-1'))
       end
 
       it 'is deregistered after Stack#delete is called' do

--- a/spec/convection/control/stack/after_update_tasks_spec.rb
+++ b/spec/convection/control/stack/after_update_tasks_spec.rb
@@ -41,7 +41,7 @@ module Convection::Control
       it 'is executed on Stack#apply' do
         subject.apply
 
-        expect(task.availability_zones).to include('eu-central-1')
+        expect(task.availability_zones).to include(a_string_starting_with('eu-central-1'))
       end
 
       it 'is deregistered after Stack#apply is called' do

--- a/spec/convection/control/stack/before_create_tasks_spec.rb
+++ b/spec/convection/control/stack/before_create_tasks_spec.rb
@@ -39,7 +39,7 @@ module Convection::Control
       it 'is executed on Stack#apply' do
         subject.apply
 
-        expect(task.availability_zones).to include('eu-central-1')
+        expect(task.availability_zones).to include(a_string_starting_with('eu-central-1'))
       end
 
       it 'is deregistered after Stack#apply is called' do

--- a/spec/convection/control/stack/before_delete_tasks_spec.rb
+++ b/spec/convection/control/stack/before_delete_tasks_spec.rb
@@ -38,7 +38,7 @@ module Convection::Control
       it 'is executed on Stack#delete' do
         subject.delete
 
-        expect(task.availability_zones).to include('eu-central-1')
+        expect(task.availability_zones).to include(a_string_starting_with('eu-central-1'))
       end
 
       it 'is deregistered after Stack#delete is called' do

--- a/spec/convection/control/stack/before_update_tasks_spec.rb
+++ b/spec/convection/control/stack/before_update_tasks_spec.rb
@@ -42,7 +42,7 @@ module Convection::Control
       it 'is executed on Stack#apply' do
         subject.apply
 
-        expect(task.availability_zones).to include('eu-central-1')
+        expect(task.availability_zones).to include(a_string_starting_with('eu-central-1'))
       end
 
       it 'is deregistered after Stack#apply is called' do

--- a/spec/convection/control/stack_spec.rb
+++ b/spec/convection/control/stack_spec.rb
@@ -23,7 +23,6 @@ module Convection::Control
         allow(Aws::EC2::Client).to receive(:new).and_return(ec2_client)
       end
       subject do
-        scope = self
         Convection::Control::Stack.new('EC2 VPC Test Stack', template)
       end
 

--- a/spec/convection/control/stack_spec.rb
+++ b/spec/convection/control/stack_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+module Convection::Control
+  describe Stack do
+    let(:template) do
+      Convection.template do
+        description 'EC2 VPC Test Template'
+
+        ec2_vpc 'TargetVPC' do
+          network '10.0.0.0'
+          subnet_length 24
+          enable_dns
+        end
+      end
+    end
+
+    describe 'stack' do
+      include_context 'with a mock CloudFormation client'
+      include_context 'with a mock EC2 client'
+
+      before do
+        allow(Aws::CloudFormation::Client).to receive(:new).and_return(cf_client)
+        allow(Aws::EC2::Client).to receive(:new).and_return(ec2_client)
+      end
+      subject do
+        scope = self
+        Convection::Control::Stack.new('EC2 VPC Test Stack', template)
+      end
+
+      it 'availability_zones are stored in an array' do
+        expect(subject.availability_zones).to be_a(Array)
+      end
+
+      it 'availability_zones are in the same region' do
+        azs = subject.availability_zones
+        azs.map! { |r| r.match(/(\w{2}-\w+-\d)/)[1] }
+        azs.uniq!
+        expect(azs.size).to be(1)
+      end
+    end
+  end
+end

--- a/spec/ec2_client_context.rb
+++ b/spec/ec2_client_context.rb
@@ -1,6 +1,6 @@
 RSpec.shared_context 'with a mock EC2 client' do
   let(:ec2_availability_zone_description) do
-    zones = %w(eu-central-1 eu-west-1).map do |name|
+    zones = %w(eu-central-1a eu-central-1b).map do |name|
       double("availability zone (#{name})", zone_name: name)
     end
 


### PR DESCRIPTION
This changes the `describe_availability_zones` double so that it returns
a list of availability_zones.

Fixes #229 