### PR TITLE
Only pass exclude_availability_zones option if set

### DIFF
--- a/lib/convection/model/cloudfile.rb
+++ b/lib/convection/model/cloudfile.rb
@@ -33,7 +33,7 @@ module Convection
       # @see Convection::Control::Stack#initialize
       def stack(stack_name, template, options = {}, &block)
         options[:region] ||= region
-        options[:exclude_availability_zones] = exclude_availability_zones
+        options[:exclude_availability_zones] = exclude_availability_zones unless exclude_availability_zones.nil?
         options[:cloud] = name
         options[:attributes] = attributes
         options[:retry_limit] = retry_limit

--- a/spec/convection/control/stack_spec.rb
+++ b/spec/convection/control/stack_spec.rb
@@ -57,6 +57,10 @@ module Convection::Control
       it 'can get default availability_zones' do
         expect(subject.availability_zones).to contain_exactly('eu-central-1a', 'eu-central-1b')
       end
+
+      it 'can get default exclude_availability_zones' do
+        expect(subject.exclude_availability_zones).to match_array([])
+      end
     end
   end
 end

--- a/spec/convection/model/cloudfile_spec.rb
+++ b/spec/convection/model/cloudfile_spec.rb
@@ -3,11 +3,32 @@ require 'stringio'
 
 module Convection::Model
   describe Cloudfile do
+    let(:template) do
+      Convection.template do
+        description 'EC2 VPC Test Template'
+
+        ec2_vpc 'TargetVPC' do
+          network '10.0.0.0'
+          subnet_length 24
+          enable_dns
+        end
+      end
+    end
+
     describe 'stack' do
       subject do
-        klass = Class.new
-        klass.extend(Convection::DSL::Cloudfile)
-        klass
+        # initialize does too much to call that directly
+        # setup only what we need for testing... :/
+        class TestCloudfile < Convection::Model::Cloudfile
+          def initialize(_)
+            @attributes = Convection::Model::Attributes.new
+            @stacks = {}
+            @deck = []
+            @stack_groups = {}
+            @thread_count ||= 2
+          end
+        end
+        TestCloudfile.new(nil)
       end
 
       it 'can get cloud name' do
@@ -23,6 +44,12 @@ module Convection::Model
       it 'can exclude_availability_zones an availability_zone' do
         subject.exclude_availability_zones %w(eu-central-1a)
         expect(subject.exclude_availability_zones).to contain_exactly('eu-central-1a')
+      end
+
+      it 'can get default exclude_availability_zones' do
+        subject.stack('test-stack', template, :region => 'us-east-1')
+        stack = subject.stacks['test-stack']
+        expect(stack.exclude_availability_zones).to match_array([])
       end
     end
   end


### PR DESCRIPTION
<!-- Remove any sections that do not apply to your changes. HTML comments are ignored. -->
# Description
This change will only pass the `exclude_availability_zones option` to the `Stack` controller if the option is set in the Cloudfile.

# Motivation and Context
<!-- Describe the use case that requires your changes. -->
This address #234 which was introduced in #232.

@erran-r7 @rdickey-r7 

