### PR TITLE
Print out error message correctly when there is one

### DIFF
--- a/bin/convection
+++ b/bin/convection
@@ -240,7 +240,7 @@ module Convection
 
         errors.each do |error|
           error = RuntimeError.new(error) if error.is_a?(String)
-          say "* #{ error_message }"
+          say "* #{ error.message }"
           error.backtrace.each { |trace| say "    #{ trace }" }
         end
       end


### PR DESCRIPTION
<!-- Remove any sections that do not apply to your changes. HTML comments are ignored. -->
# Description
Commit a7c43b71c7f93c9250877155cae9840e52c3db4a broke error message printing by trying to print a variable that doesn't exist.  This fixes that glitch.

# Motivation and Context
<!-- Describe the use case that requires your changes. -->

# Usage Examples
<!-- Code or screenshot examples of using your feature, if applicable. -->

# Testing Steps
<!-- List any steps required to test your changes. -->

# Post-merge Steps
<!-- List any steps required after merging your changes. -->
