### PR TITLE
Add support for AWS::Logs::SubscriptionFilter

### DIFF
--- a/lib/convection/model/template/resource/aws_logs_subscription_filter.rb
+++ b/lib/convection/model/template/resource/aws_logs_subscription_filter.rb
@@ -8,7 +8,7 @@ module Convection
         # AWS::Logs::SubscriptionFilter
         ##
         class SubscriptionFilter < Resource
-          type 'AWS::Logs::SubscriptionFilter'
+          type 'AWS::Logs::SubscriptionFilter', :logs_subscription_filter
           property :destination_arn, 'DestinationArn'
           property :filter_pattern, 'FilterPattern'
           property :log_group_name, 'LogGroupName'

--- a/lib/convection/model/template/resource/aws_logs_subscription_filter.rb
+++ b/lib/convection/model/template/resource/aws_logs_subscription_filter.rb
@@ -1,0 +1,20 @@
+require_relative '../resource'
+
+module Convection
+  module Model
+    class Template
+      class Resource
+        ##
+        # AWS::Logs::SubscriptionFilter
+        ##
+        class SubscriptionFilter < Resource
+          type 'AWS::Logs::SubscriptionFilter'
+          property :destination_arn, 'DestinationArn'
+          property :filter_pattern, 'FilterPattern'
+          property :log_group_name, 'LogGroupName'
+          property :role_arn, 'RoleArn'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Define `logs_subscription_filter` DSL for `AWS::Logs::SubscriptionFilter`.