### PR TITLE
Fix verb tense of pre-"delete" status

### DIFF
--- a/lib/convection/control/cloud.rb
+++ b/lib/convection/control/cloud.rb
@@ -100,7 +100,7 @@ module Convection
             next
           end
 
-          block.call(Model::Event.new(:deleted, "Delete remote stack #{ stack.cloud_name }", :info)) if block
+          block.call(Model::Event.new(:delete, "Delete remote stack #{ stack.cloud_name }", :info)) if block
           stack.delete(&block)
 
           if stack.error?


### PR DESCRIPTION
# Description
We use "deleted" past tense when we should be using just "delete" in the status.

## Before
```
deleted  Delete remote stack example-corp-0-dnsproxysecondary
```

## After
```
delete  Delete remote stack example-corp-0-dnsproxysecondary
```