### PR TITLE
Fix #246 - Raise an error when users try to print a non-existent stack

### DIFF
--- a/bin/convection
+++ b/bin/convection
@@ -71,6 +71,11 @@ module Convection
     option :cloudfile, :type => :string, :default => 'Cloudfile'
     def print_template(stack)
       init_cloud
+      unless @cloud.stacks.key?(stack)
+        warn "No stack #{stack.inspect} found. Did you define it in #{options[:cloudfile]}?"
+        exit 1
+      end
+
       puts @cloud.stacks[stack].to_json(true)
     end
 


### PR DESCRIPTION
Fix #246.