### PR TITLE
Lock mixlib-shellout to 2.2.7 for pre ruby 2.2 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,6 @@ group :development do
   gem 'simplecov'
   gem 'thor-scmversion', '= 1.7.0'
   gem 'yard'
+  # TODO: Remove mixlib dependency once we lock to Ruby >= 2.2.
+  gem 'mixlib-shellout', '= 2.2.7'
 end


### PR DESCRIPTION
# Description
This should fix the issue @mbroomfield-r7 is getting unrelated to his changes.

**NOTE**: We may just be better locking to `>= 2.3` and bumping a major version to prevent similar issues from happening in the foreseeable future.