### PR TITLE
Make info messages cyan instead of green

### DIFF
--- a/lib/convection/model/event.rb
+++ b/lib/convection/model/event.rb
@@ -14,7 +14,8 @@ module Convection
       attr_accessor :level
       attr_accessor :timestamp
       colorize :level,
-               :green => [:info, :success, Control::Stack::CREATE_COMPLETE, Control::Stack::UPDATE_COMPLETE, Control::Stack::UPDATE_ROLLBACK_COMPLETE,
+               :cyan => [:info],
+               :green => [:success, Control::Stack::CREATE_COMPLETE, Control::Stack::UPDATE_COMPLETE, Control::Stack::UPDATE_ROLLBACK_COMPLETE,
                           Control::Stack::TASK_COMPLETE],
                :red => [:error, :fail, Control::Stack::CREATE_FAILED, Control::Stack::ROLLBACK_FAILED,
                         Control::Stack::DELETE_FAILED, Control::Stack::UPDATE_FAILED,


### PR DESCRIPTION
<!-- Remove any sections that do not apply to your changes. HTML comments are ignored. -->
# Description
Changes info messages to be cyan, rather than green.

Before:
![screen shot 2017-07-19 at 2 53 20 pm](https://user-images.githubusercontent.com/22451912/28890519-f9f83c52-778c-11e7-94df-e423114cb6c2.png)
![screen shot 2017-07-20 at 10 07 44 am](https://user-images.githubusercontent.com/22451912/28890531-03643f98-778d-11e7-9f02-1f3f5c4b07c9.png)

After:
![screen shot 2017-07-20 at 10 05 01 am](https://user-images.githubusercontent.com/22451912/28890545-0c7adab0-778d-11e7-927f-5272c645916a.png)
![screen shot 2017-07-20 at 10 06 10 am](https://user-images.githubusercontent.com/22451912/28890547-106d256a-778d-11e7-9787-85c52160416d.png)


# Motivation and Context
When running a `diff --vv`, it's sometimes hard to see one change in a
sea of unchanged stack info messages.  This is because the `compare` and
`create` and `update` look very similar given the color.  With this new
change, `compare` and `unchanged` will be cyan, but `create` and
`update` will continue to show as green.


<!-- Describe the use case that requires your changes. -->

# Usage Examples
<!-- Code or screenshot examples of using your feature, if applicable. -->
This has been tested on both a black and a white background, so should
have minimal annoyance factor across a range of color palates.

# Testing Steps
<!-- List any steps required to test your changes. -->
Just run a `convection diff --vv`

# Post-merge Steps
<!-- List any steps required after merging your changes. -->
Dance
![](https://media.giphy.com/media/IB9foBA4PVkKA/giphy.gif)