### PR TITLE
Add the AcmCertificateArn property to CloudFront

### DIFF
--- a/lib/convection/model/template/resource_property/aws_cloudfront_viewercertificate.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_viewercertificate.rb
@@ -9,6 +9,7 @@ module Convection
         class CloudFrontViewerCertificate < ResourceProperty
           property :use_default, 'CloudFrontDefaultCertificate'
           property :iam_certificate, 'IamCertificateId'
+          property :acm_certificate, 'AcmCertificateArn'
           property :minimum_protocol_version, 'MinimumProtocolVersion'
           property :ssl_support_method, 'SslSupportMethod'
         end

--- a/lib/convection/model/template/resource_property/aws_cloudfront_viewercertificate.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_viewercertificate.rb
@@ -9,7 +9,7 @@ module Convection
         class CloudFrontViewerCertificate < ResourceProperty
           property :use_default, 'CloudFrontDefaultCertificate'
           property :iam_certificate, 'IamCertificateId'
-          property :acm_certificate, 'AcmCertificateArn'
+          property :acm_certificate_arn, 'AcmCertificateArn'
           property :minimum_protocol_version, 'MinimumProtocolVersion'
           property :ssl_support_method, 'SslSupportMethod'
         end


### PR DESCRIPTION
# Description

This adds support for using ACM certificates in CloudFront distributions.

# Motivation and Context
New SSL certificates, even imported 3rd party certificates, use the new ACM certificate functionality in AWS.  This replaces the old IAM certificates.  To use these in convection, the CloudFormation `AcmCertificateArn` property must be used.

# Usage Examples
```ruby
cloudfront_distribution 'FooCloudFront' do
  config do
    ...
    viewer_certificate do
      acm_certificate_arn 'arn:aws:acm:us-east-1:XXXXXXXXXXXX:certificate/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
      ssl_support_method 'sni-only'
    end
  end
end
```

# Testing Steps
Converged a stack using this branch.
