### PR TITLE
Add a few new flags to convection terraform-export

### DIFF
--- a/bin/convection
+++ b/bin/convection
@@ -122,13 +122,16 @@ module Convection
     option :module_path, desc: 'The module path prefix for terraform', default: DEFAULT_MODULE_PATH
     option :output_directory, desc: 'The directory to create configuration files under', aliases: %w(-d --dir), default: '.'.freeze
     option :cloudfile, desc: 'The cloudfile to load', default: 'Cloudfile'
+    option :confirm_root, desc: 'Prompt to confirm module path when --module-path="root"', default: true, type: :boolean
+    option :overwrite, desc: 'Overwrite any conflicting tf.json files in --output-directory', default: false, type: :boolean
+    option :skip_existing, desc: 'Skip any conflicting tf.json files in --output-directory', default: false, type: :boolean
     def terraform_export(stack_name)
       if options[:output_directory].empty?
         say_status :error, '--output-directory must not be empty.', :red
         exit 1
       end
 
-      if options[:module_path] == DEFAULT_MODULE_PATH
+      if options[:confirm_root] && options[:module_path] == DEFAULT_MODULE_PATH
         say_status :warning, '--module-path was set to "root".', :yellow
         exit 0 unless yes?('Are you sure you want to generate terraform import commands in the root namespace?')
       end
@@ -147,7 +150,8 @@ module Convection
       def import_resources(_resource_name, resource)
         if resource.respond_to?(:to_hcl_json)
           empty_directory options[:output_directory]
-          create_file File.join(options[:output_directory], "#{resource.name.downcase}.tf.json"), resource.to_hcl_json
+          destination = File.join(options[:output_directory], "#{resource.name.downcase}.tf.json")
+          create_file destination, resource.to_hcl_json, force: options[:overwrite], skip: options[:skip_existing]
         else
           say "# Unable to generate terraform configuration for #{resource.class}. Define #{resource.class}#to_hcl_json to do so.", :yellow
         end


### PR DESCRIPTION
* `--[no-]confirm-root` will supress the warning when generating resources under the root terraform module path.
* `--[no-]overwrite` will force overwriting any existing tf.json files to be generated.
* `--[no-]skip` will force skipping generating any existing tf.json files.