### PR TITLE
Overload all users of IntrinsicFunctions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,14 +24,16 @@ Performance/RedundantBlockCall:
 Style/SignalException:
   Enabled: false
 
+Metrics/LineLength:
+  Exclude:
+    - 'lib/convection/dsl/terraform_intrinsic_functions.rb'
+
 # AbcSize:
 #   Max: 24
 # ClassLength:
 #   Max: 256
 # CyclomaticComplexity:
 #   Max: 12
-# LineLength:
-#   Max: 120
 # MethodLength:
 #   Max: 32
 # PerceivedComplexity:

--- a/bin/convection
+++ b/bin/convection
@@ -158,8 +158,6 @@ module Convection
 
       private
 
-      # rubocop:disable Style/AsciiComments
-
       def import_resources(_resource_name, resource)
         # Reload this resource to ensure configuration is up to date. Amazon psuedo functions will have changed their return values.
         resource.execute
@@ -188,8 +186,6 @@ module Convection
 
         puts # Print an additional new line
       end
-
-      # rubocop:enable Style/AsciiComments
 
       def operation(task_name, stack)
         work_q = Queue.new

--- a/bin/convection
+++ b/bin/convection
@@ -161,6 +161,9 @@ module Convection
       # rubocop:disable Style/AsciiComments
 
       def import_resources(_resource_name, resource)
+        # Reload this resource to ensure configuration is up to date. Amazon psuedo functions will have changed their return values.
+        resource.execute
+
         if resource.respond_to?(:to_hcl_json)
           empty_directory options[:output_directory]
           destination = File.join(options[:output_directory], "#{resource.name.downcase}.tf.json")

--- a/bin/convection
+++ b/bin/convection
@@ -140,13 +140,13 @@ module Convection
 
       init_cloud
       template = @cloud.stacks.fetch(stack_name).template
-      # Beware of 🐲. This patches this Template to include terraform compatible intrinsic functions where possible.
+
+      # Beware of 🐲. This patches this instance to include terraform compatible intrinsic functions where possible.
       #
       # This should only be done in single threaded environment in the terraform-export command as it breaks usage of cloudformation psuedo-functions.
-      #
-      # e.g. #get_att("Bucket", "Arn") returns "aws_s3_bucket.bucket.arn" instead of { "Fn::GetAtt" => ["Bucket", "Arn"] }.
       require 'convection/dsl/terraform_intrinsic_functions'
-      template.extend(Convection::DSL::TerraformIntrinsicFunctions)
+      Convection::DSL::TerraformIntrinsicFunctions.overload(Convection::DSL::IntrinsicFunctions.mixers)
+
       template.resource_collections.each(&method(:import_resources))
       template.resources.each(&method(:import_resources))
     end
@@ -161,12 +161,6 @@ module Convection
       # rubocop:disable Style/AsciiComments
 
       def import_resources(_resource_name, resource)
-        # Beware of 🐲. This patches this instance to include terraform compatible intrinsic functions where possible.
-        #
-        # This should only be done in single threaded environment in the terraform-export command as it breaks usage of cloudformation psuedo-functions.
-        require 'convection/dsl/terraform_intrinsic_functions'
-        resource.extend(Convection::DSL::TerraformIntrinsicFunctions)
-
         if resource.respond_to?(:to_hcl_json)
           empty_directory options[:output_directory]
           destination = File.join(options[:output_directory], "#{resource.name.downcase}.tf.json")

--- a/lib/convection/dsl/helpers.rb
+++ b/lib/convection/dsl/helpers.rb
@@ -35,6 +35,8 @@ module Convection
 
       class << self
         def included(mod)
+          DSL::IntrinsicFunctions.mixers << mod
+
           mod.extend(DSL::ClassHelpers)
         end
 

--- a/lib/convection/dsl/intrinsic_functions.rb
+++ b/lib/convection/dsl/intrinsic_functions.rb
@@ -1,8 +1,20 @@
+require 'set'
+
 module Convection
   module DSL
     ##
     # Formatting helpers for Intrinsic Functions
     module IntrinsicFunctions
+      def self.included(base)
+        mixers << base
+
+        super
+      end
+
+      def self.mixers
+        @mixers ||= Set.new
+      end
+
       def base64(content)
         {
           'Fn::Base64' => content

--- a/lib/convection/dsl/terraform_intrinsic_functions.rb
+++ b/lib/convection/dsl/terraform_intrinsic_functions.rb
@@ -1,8 +1,20 @@
-require 'active_support/core_ext/string/inflections'
-
 module Convection
   module DSL
     module TerraformIntrinsicFunctions
+      # lazily require inflections so loaded when invoking terraform-export.
+      require 'active_support/core_ext/string/inflections'
+
+      def self.extended(base)
+        return base.include(self) if Class === base || Module === base
+
+        super
+      end
+
+      def self.overload(objects)
+        mod = self
+        objects.each { |o| o.extend(mod) }
+      end
+
       def base64(_content)
         %q(base64(#{content.to_json}))
       end

--- a/lib/convection/dsl/terraform_intrinsic_functions.rb
+++ b/lib/convection/dsl/terraform_intrinsic_functions.rb
@@ -20,72 +20,79 @@ module Convection
       end
 
       def fn_and(*)
-        warn "WARNING: Condition functions cannot be inferred when migrating to terraform. Please set count on migrated resources manually. #{self.class}(#{name})"
+        warn "WARNING: Condition functions cannot be inferred when migrating to terraform. Please set count on migrated resources manually. #{self.class}(#{terraform_name})"
         '${todo.fn_and.ATTRIBUTE.set_in_count}'
       end
 
       def fn_equals(*)
-        warn "WARNING: Condition functions cannot be inferred when migrating to terraform. Please set count on migrated resources manually. #{self.class}(#{name})"
+        warn "WARNING: Condition functions cannot be inferred when migrating to terraform. Please set count on migrated resources manually. #{self.class}(#{terraform_name})"
         '${todo.fn_equals.ATTRIBUTE.set_in_count}'
       end
 
       def fn_if(*)
-        warn "WARNING: Condition functions cannot be inferred when migrating to terraform. Please set count on migrated resources manually. #{self.class}(#{name})"
+        warn "WARNING: Condition functions cannot be inferred when migrating to terraform. Please set count on migrated resources manually. #{self.class}(#{terraform_name})"
         '${todo.fn_if.ATTRIBUTE.set_in_count}'
       end
 
       def fn_import_value(*)
-        warn "WARNING: Fn::ImportValue cannot be inferred when migrated to terraform. Please pull in this input through a variable or local value in your configuration. #{self.class}(#{name})"
+        warn "WARNING: Fn::ImportValue cannot be inferred when migrated to terraform. Please pull in this input through a variable or local value in your configuration. #{self.class}(#{terraform_name})"
         '${todo.fn_import_value.ATTRIBUTE}'
       end
 
       def fn_not(*)
-        warn "WARNING: Condition functions cannot be inferred when migrating to terraform. Please set count on migrated resources manually. #{self.class}(#{name})"
+        warn "WARNING: Condition functions cannot be inferred when migrating to terraform. Please set count on migrated resources manually. #{self.class}(#{terraform_name})"
         '${todo.fn_not.ATTRIBUTE.set_in_count}'
       end
 
       def fn_or(*)
-        warn "WARNING: Condition functions cannot be inferred when migrating to terraform. Please set count on migrated resources manually. #{self.class}(#{name})"
+        warn "WARNING: Condition functions cannot be inferred when migrating to terraform. Please set count on migrated resources manually. #{self.class}(#{terraform_name})"
         '${todo.fn_or.ATTRIBUTE.set_in_count}'
       end
 
       def fn_sub(*)
-        warn "WARNING: Fn::Sub cannot be inferred when migrating to terraform. Please use ${replace(str, search, replace)} instead. #{self.class}(#{name})"
+        warn "WARNING: Fn::Sub cannot be inferred when migrating to terraform. Please use ${replace(str, search, replace)} instead. #{self.class}(#{terraform_name})"
         '${replace(todo.fn_sub.STRING, todo.fn_sub.SEARCH, todo.fn_sub.REPLACE)}'
       end
 
       def find_in_map(*)
-        warn "WARNING: Fn::FindInMap cannot be inferred when migrating to terraform. Please consult with the interpolation syntax terraform docs #{self.class}(#{name})"
+        warn "WARNING: Fn::FindInMap cannot be inferred when migrating to terraform. Please consult with the interpolation syntax terraform docs #{self.class}(#{terraform_name})"
         '${lookup(lookup(YOUR_MAP, YOUR_TOP_LEVEL_KEY), YOUR_NESTED_KEY)}'
       end
 
       def get_att(resource_name, attr_name)
         interpolation_string = "${#{terraform_resource_type(resource_name)}.#{terraform_resource_name(resource_name)}.#{attr_name.underscore}}"
-        warn "WARNING: Inferring you want to use #{interpolation_string} in place of Fn::GetAtt. Please consult with the interpolation syntax terraform docs and docs for this resource type in terraform to verify compatablity. #{self.class}(#{name})"
+        warn "WARNING: Inferring you want to use #{interpolation_string} in place of Fn::GetAtt. Please consult with the interpolation syntax terraform docs and docs for this resource type in terraform to verify compatablity. #{self.class}(#{terraform_name})"
         interpolation_string
       end
 
       def get_azs(*)
-        warn "WARNING: Inferring you want to use ${var.availability_zones} instead of Fn::GetAZs. Please consult with the interpolation syntax terraform docs to verify compatablity. Additionally you should attempt to use variables in place of a literal list. #{self.class}(#{name})"
+        warn "WARNING: Inferring you want to use ${var.availability_zones} instead of Fn::GetAZs. Please consult with the interpolation syntax terraform docs to verify compatablity. Additionally you should attempt to use variables in place of a literal list. #{self.class}(#{terraform_name})"
         '${var.availability_zones}'
       end
 
       def join(delimiter, *values)
         interpolation_string = "${join(\"#{delimiter}\", list(#{values.map { |o| "\"#{o}\"" }.join(', ')}))"
-        warn "WARNING: Inferring you want to use #{interpolation_string} in place of Fn::Join. Please consult with the interpolation syntax terraform docs to verify compatablity. Additionally you should attempt to use variables in place of a literal list. #{self.class}(#{name})"
+        warn "WARNING: Inferring you want to use #{interpolation_string} in place of Fn::Join. Please consult with the interpolation syntax terraform docs to verify compatablity. Additionally you should attempt to use variables in place of a literal list. #{self.class}(#{terraform_name})"
         interpolation_string
       end
 
       def select(index, *objects)
         interpolation_string = "${element(list(#{objects.map { |o| "\"#{o}\"" }.join(', ')}), #{index})"
-        warn "WARNING: Inferring you want to use #{interpolation_string} in place of Fn::Select. Please consult with the interpolation syntax terraform docs to verify compatablity. Additionally you should attempt to use variables in place of a literal list. #{self.class}(#{name})"
+        warn "WARNING: Inferring you want to use #{interpolation_string} in place of Fn::Select. Please consult with the interpolation syntax terraform docs to verify compatablity. Additionally you should attempt to use variables in place of a literal list. #{self.class}(#{terraform_name})"
         interpolation_string
       end
 
       def fn_ref(resource_name)
         interpolation_string = "${#{terraform_resource_type(resource_name)}.#{terraform_resource_name(resource_name)}.id}"
-        warn "WARNING: Inferring you want to use #{interpolation_string} in place of Fn::Ref. Please consult with the interpolation syntax terraform docs and docs for this resource type in terraform to verify compatablity. #{self.class}(#{name})"
+        warn "WARNING: Inferring you want to use #{interpolation_string} in place of Fn::Ref. Please consult with the interpolation syntax terraform docs and docs for this resource type in terraform to verify compatablity. #{self.class}(#{terraform_name})"
         interpolation_string
+      end
+
+      def terraform_name
+        return name if respond_to?(:name)
+        return sid if respond_to?(:sid)
+
+        object_id
       end
 
       def terraform_resource_name(resource_name)

--- a/lib/convection/dsl/terraform_intrinsic_functions.rb
+++ b/lib/convection/dsl/terraform_intrinsic_functions.rb
@@ -1,11 +1,12 @@
 module Convection
   module DSL
+    # AWS psuedo-functions overridden to be terraform compatible, sort of!
     module TerraformIntrinsicFunctions
-      # lazily require inflections so loaded when invoking terraform-export.
+      # Lazily require inflections so loaded when invoking terraform-export.
       require 'active_support/core_ext/string/inflections'
 
       def self.extended(base)
-        return base.include(self) if Class === base || Module === base
+        return base.include(self) if base.is_a?(Class) || base.is_a?(Module)
 
         super
       end


### PR DESCRIPTION
# Current Behaviour
Currently intrinsic functions are only being overridden for `Resource`s  and `ResourceCollection`s.

# Expected Behaviour
Intrinsic functions called from anywhere should be overridden by terraform intrinsic functions.