### PR TITLE
Support a hash of additional hcl files to generate

### DIFF
--- a/bin/convection
+++ b/bin/convection
@@ -244,12 +244,19 @@ module Convection
       private
 
       def import_resources(_resource_name, resource)
+        empty_directory options[:output_directory] if resource.respond_to?(:to_hcl_json) || resource.respond_to?(:additional_hcl_files)
         if resource.respond_to?(:to_hcl_json)
-          empty_directory options[:output_directory]
-          destination = File.join(options[:output_directory], "#{resource.name.downcase}.tf.json")
+          destination = File.join(options[:output_directory], "#{resource.name.underscore}.tf.json")
           create_file destination, resource.to_hcl_json, force: options[:overwrite], skip: options[:skip_existing]
         else
           say "# Unable to generate terraform configuration for #{resource.class}. Define #{resource.class}#to_hcl_json to do so.", :yellow
+        end
+
+        if resource.respond_to?(:additional_hcl_files)
+          resource.additional_hcl_files.each do |file, content|
+            destination = File.join(options[:output_directory], file)
+            create_file destination, content, force: options[:overwrite], skip: options[:skip_existing]
+          end
         end
 
         if resource.respond_to?(:terraform_import_commands)


### PR DESCRIPTION
Add support for using `Resource#additional_hcl_files`/`ResourceCollection#additional_hcl_files` to generate additional HCL files.

Usage:

```ruby
# Values can be any object that generates a JSON Object on `#to_json`.
def additional_hcl_files
  {
    'hello_world.tf.json': { aws_s3_bucket: { mybucketname: { ... } } },
  }
end
```