### PR TITLE
Pass :module_path through to additional_hcl_files

### DIFF
--- a/bin/convection
+++ b/bin/convection
@@ -247,7 +247,7 @@ module Convection
         empty_directory options[:output_directory] if resource.respond_to?(:to_hcl_json) || resource.respond_to?(:additional_hcl_files)
         if resource.respond_to?(:to_hcl_json)
           destination = File.join(options[:output_directory], "#{resource.name.underscore}.tf.json")
-          create_file destination, resource.to_hcl_json, force: options[:overwrite], skip: options[:skip_existing]
+          create_file destination, resource.to_hcl_json(module_path: options[:module_path]), force: options[:overwrite], skip: options[:skip_existing]
         elsif resource.respond_to?(:additional_hcl_files)
           say "# Skipping to HCL generation with #to_hcl_json. Will generate HCL using #additional_hcl_files instead.", :cyan
         else

--- a/bin/convection
+++ b/bin/convection
@@ -255,8 +255,9 @@ module Convection
         end
 
         if resource.respond_to?(:additional_hcl_files)
-          resource.additional_hcl_files.each do |file, content|
+          resource.additional_hcl_files(module_path: options[:module_path]).each do |file, content|
             destination = File.join(options[:output_directory], file.to_s)
+            empty_directory File.dirname(destination) if file.to_s.include?('/')
             create_file destination, content.to_json, force: options[:overwrite], skip: options[:skip_existing]
           end
         end


### PR DESCRIPTION
# Description
Currently resource collections must define `terraform_import_commands` and save an instance variable to use the `--module-path` flag. This passes it directly into the `additional_hcl_files` function.