### PR TITLE
Feature: EC2 Route Terraform support

### DIFF
--- a/lib/convection/model/template/resource/aws_ec2_route.rb
+++ b/lib/convection/model/template/resource/aws_ec2_route.rb
@@ -39,7 +39,7 @@ module Convection
             { resource: tf_record }.to_json
           end
 
-          def terraform_import_commands(module_path: 'root')
+          def terraform_import_commands(*)
             ['# Route import is not supported by Terraform.']
           end
         end

--- a/lib/convection/model/template/resource/aws_ec2_route.rb
+++ b/lib/convection/model/template/resource/aws_ec2_route.rb
@@ -16,6 +16,32 @@ module Convection
           property :instance, 'InstanceId'
           property :interface, 'NetworkInterfaceId'
           property :peer, 'VpcPeeringConnectionId'
+
+          def to_hcl_json(*)
+            tf_record_attrs = {
+              route_table_id: route_table_id,
+              destination_cidr_block: destination,
+              vpc_peering_connection_id: peer,
+              gateway_id: gateway,
+              nat_gateway_id: nat_gateway,
+              instance_id: instance,
+              network_interface_id: interface
+            }
+
+            tf_record_attrs.reject! { |_, v| v.nil? }
+
+            tf_record = {
+              aws_route: {
+                name.underscore => tf_record_attrs
+              }
+            }
+
+            { resource: tf_record }.to_json
+          end
+
+          def terraform_import_commands(module_path: 'root')
+            ['# Route import is not supported by Terraform.']
+          end
         end
       end
     end


### PR DESCRIPTION
This adds support for exporting `AWS::EC2::Route` and `AWS::EC2::RouteTable` resources to Terraform. Terraform doesn't support importing `AWS::EC2::Route` objects, so you'll want to import Route Table resources, add Route resources, and then run `terraform plan` to check that everything's okay.
  