### PR TITLE
Adds support for creating AWS::Elasticsearch::Domain, missing CloudFrontCacheBehavior 'Compress' and CloudFrontDistributionConfig 'HttpVersion' properties

### DIFF
--- a/lib/convection/model/template/resource/aws_elasticsearch_domain.rb
+++ b/lib/convection/model/template/resource/aws_elasticsearch_domain.rb
@@ -1,0 +1,63 @@
+require_relative '../resource'
+
+module Convection
+  module Model
+    class Template
+      class Resource
+        ##
+        # AWS::Elasticsearch::Domain
+        ##
+        class ElasticsearchDomain < Resource
+          include Model::Mixin::Taggable
+
+          type 'AWS::Elasticsearch::Domain', :elasticsearch_domain
+          property :domain_name, 'DomainName'
+          property :elasticsearch_version, 'ElasticsearchVersion'
+          property :elasticsearch_cluster_config, 'ElasticsearchClusterConfig'
+          property :access_policies, 'AccessPolicies'
+          property :vpc_options, 'VPCOptions'
+          property :ebs_options, 'EBSOptions'
+          property :snapshot_options, 'SnapshotOptions'
+          property :advanced_options, 'AdvancedOptions'
+
+          def elasticsearch_cluster_config(&block)
+            elasticsearch_cluster_config = ResourceProperty::ElasticsearchDomainElasticsearchClusterConfig.new(self)
+            elasticsearch_cluster_config.instance_exec(&block) if block
+            properties['ElasticsearchClusterConfig'].set(elasticsearch_cluster_config)
+          end
+
+          def vpc_options(&block)
+            vpc_options = ResourceProperty::ElasticsearchDomainVPCOptions.new(self)
+            vpc_options.instance_exec(&block) if block
+            properties['VPCOptions'].set(vpc_options)
+          end
+
+          def ebs_options(&block)
+            ebs_options = ResourceProperty::ElasticsearchDomainEBSOptions.new(self)
+            ebs_options.instance_exec(&block) if block
+            properties['EBSOptions'].set(ebs_options)
+          end
+
+          def snapshot_options(&block)
+            snapshot_options = ResourceProperty::ElasticsearchDomainSnapshotOptions.new(self)
+            snapshot_options.instance_exec(&block) if block
+            properties['SnapshotOptions'].set(snapshot_options)
+          end
+
+          def advanced_options(&block)
+            advanced_options = ResourceProperty::ElasticsearchDomainAdvancedOptions.new(self)
+            advanced_options.instance_exec(&block) if block
+            properties['AdvancedOptions'].set(advanced_options)
+          end
+
+          def render(*args)
+            super.tap do |resource|
+              render_tags(resource)
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource/aws_elasticsearch_domain.rb
+++ b/lib/convection/model/template/resource/aws_elasticsearch_domain.rb
@@ -55,7 +55,6 @@ module Convection
               render_tags(resource)
             end
           end
-
         end
       end
     end

--- a/lib/convection/model/template/resource_property/aws_cloudfront_cachebehavior.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_cachebehavior.rb
@@ -9,6 +9,7 @@ module Convection
         class CloudFrontCacheBehavior < ResourceProperty
           property :allowed_methods, 'AllowedMethods', :type => :list, :default => %w(HEAD GET)
           property :cached_methods, 'CachedMethods', :type => :list
+          property :compress, 'Compress'
           property :forwarded_values, 'ForwardedValues'
           property :min_ttl, 'MinTTL'
           property :path_pattern, 'PathPattern', :default => '*'

--- a/lib/convection/model/template/resource_property/aws_cloudfront_distribution_config.rb
+++ b/lib/convection/model/template/resource_property/aws_cloudfront_distribution_config.rb
@@ -15,6 +15,7 @@ module Convection
           property :default_cache_behavior, 'DefaultCacheBehavior'
           property :default_root_object, 'DefaultRootObject'
           property :enabled, 'Enabled', :default => true
+          property :http_version, 'HttpVersion'
           property :logging, 'Logging'
           property :origins, 'Origins', :type => :list
           property :price_class, 'PriceClass'

--- a/lib/convection/model/template/resource_property/aws_elasticsearch_domain_advanced_options.rb
+++ b/lib/convection/model/template/resource_property/aws_elasticsearch_domain_advanced_options.rb
@@ -1,0 +1,16 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticsearch-domain.html#cfn-elasticsearch-domain-advancedoptions
+        # Advanced Options Property Type}
+        class ElasticsearchDomainAdvancedOptions < ResourceProperty
+          property :indices_query_bool_max_clause_count, 'indices.query.bool.max_clause_count'
+          property :rest_action_multi_allow_explicit_index, 'rest.action.multi.allow_explicit_index'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_elasticsearch_domain_advanced_options.rb
+++ b/lib/convection/model/template/resource_property/aws_elasticsearch_domain_advanced_options.rb
@@ -8,6 +8,7 @@ module Convection
         # Advanced Options Property Type}
         class ElasticsearchDomainAdvancedOptions < ResourceProperty
           property :indices_query_bool_max_clause_count, 'indices.query.bool.max_clause_count'
+          property :indices_fielddata_cache_size, 'indices.fielddata.cache.size'
           property :rest_action_multi_allow_explicit_index, 'rest.action.multi.allow_explicit_index'
         end
       end

--- a/lib/convection/model/template/resource_property/aws_elasticsearch_domain_ebs_options.rb
+++ b/lib/convection/model/template/resource_property/aws_elasticsearch_domain_ebs_options.rb
@@ -1,0 +1,18 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-ebsoptions.html
+        # EBS Options Property Type}
+        class ElasticsearchDomainEBSOptions < ResourceProperty
+          property :ebs_enabled, 'EBSEnabled'
+          property :volume_type, 'VolumeType'
+          property :volume_size, 'VolumeSize'
+          property :iops, 'Iops'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_elasticsearch_domain_elasticsearch_cluster_config.rb
+++ b/lib/convection/model/template/resource_property/aws_elasticsearch_domain_elasticsearch_cluster_config.rb
@@ -1,0 +1,20 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-elasticsearchclusterconfig.html
+        # Elasticsearch Cluster Config Property Type}
+        class ElasticsearchDomainElasticsearchClusterConfig < ResourceProperty
+          property :instance_count, 'InstanceCount'
+          property :instance_type, 'InstanceType'
+          property :dedicated_master_enabled, 'DedicatedMasterEnabled'
+          property :dedicated_master_type, 'DedicatedMasterType'
+          property :dedicated_master_count, 'DedicatedMasterCount'
+          property :zone_awareness_enabled, 'ZoneAwarenessEnabled'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_elasticsearch_domain_snapshot_options.rb
+++ b/lib/convection/model/template/resource_property/aws_elasticsearch_domain_snapshot_options.rb
@@ -1,0 +1,15 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-snapshotoptions.html
+        # Snapshot Options Property Type}
+        class ElasticsearchDomainSnapshotOptions < ResourceProperty
+          property :automated_snapshot_start_hour, 'AutomatedSnapshotStartHour'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_elasticsearch_domain_vpc_options.rb
+++ b/lib/convection/model/template/resource_property/aws_elasticsearch_domain_vpc_options.rb
@@ -1,0 +1,16 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-vpcoptions.html
+        # VPC Options Property Type}
+        class ElasticsearchDomainVPCOptions < ResourceProperty
+          property :security_group_ids, 'SecurityGroupIds', :type => :list
+          property :subnet_ids, 'SubnetIds', :type => :list
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds support for creating AWS::Elasticsearch::Domain, missing CloudFrontCacheBehavior 'Compress' and CloudFrontDistributionConfig 'HttpVersion' properties, as per CloudFormation docs:

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticsearch-domain.html

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-cachebehavior.html#cfn-cloudfront-distribution-cachebehavior-compress

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-distributionconfig.html#cfn-cloudfront-distribution-distributionconfig-httpversion