### PR TITLE
Adds support for creating AWS::RDS::DBCluster resource 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ attic
 *.gem
 *.iml
 .rakeTasks
+.idea/

--- a/lib/convection/model/template/resource/aws_rds_db_cluster.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_cluster.rb
@@ -6,45 +6,66 @@ module Convection
       class Resource
         ##
         # AWS::RDS::DBCluster
+        #
+        # @example
+        #      rds_cluster 'TestCluster' do
+        #           availability_zone 'us-east-1','us-east-2'
+        #           backup_retention 10
+        #           database_name 'test_database'
+        #           identifier 'cluster1'
+        #           cluster_parameter_group_name 'default.aurora5.6'
+        #           subnet_group 'subnet_group'
+        #           engine 'aurora'
+        #           engine_version '5.6.10a'
+        #           kms_key_id 'kms_key'
+        #           master_username 'username'
+        #           master_password 'password'
+        #           port '3306'
+        #           preferred_backup_window '12:30-01:30'
+        #           preferred_maintenance_window 'mon:2:30-mon:3:30'
+        #           replication_source_identifier 'source_instance'
+        #           snapshot_identifier
+        #           storage_encrypted 'false'
+        #           tag 'Name', 'Test'
+        #           vpc_security_group 'test_security_group_1' ,'test_security_group_2'
+        #       end
         ##
         class RDSDBCluster < Resource
           include Model::Mixin::Taggable
 
           type 'AWS::RDS::DBCluster', :rds_cluster
 
-          property :identifier, 'DBClusterIdentifier'
-          property :engine, 'Engine'
-          property :engine_version, 'EngineVersion'
-          property :storage_encrypted, 'StorageEncrypted'
-          property :port, 'Port'
+          property :availability_zone, 'AvailabilityZones', :type => :list
           property :backup_retention, 'BackupRetentionPeriod'
           property :database_name, 'DatabaseName'
-
+          property :identifier, 'DBClusterIdentifier'
+          property :cluster_parameter_group_name, 'DBClusterParameterGroupName'
+          property :subnet_group, 'DBSubnetGroupName'
+          property :engine, 'Engine'
+          property :engine_version, 'EngineVersion'
+          property :kms_key_id, 'KmsKeyId'
           #only specify username and password  if you do not specify SnapshotIdentifier
           property :master_username, 'MasterUsername'
           property :master_password, 'MasterUserPassword'
-
-          property :kms_key_id, 'KmsKeyId'
-          property :snapshot_identifier, 'SnapshotIdentifier'
-
+          property :port, 'Port'
           #backup window must be in the format hh24:mi-hh24:mi, atleast 30 mins long, UTC, cannot conflict with maintenance window.
           property :preferred_backup_window, 'PreferredBackupWindow'
           #backup window must be in the format ddd:hh24:mi-ddd:hh24:mi, atleast 30 mins long, UTC, cannot conflict with backup window.
           property :preferred_maintenance_window, 'PreferredMaintenanceWindow'
-
-          property :availability_zone, 'AvailabilityZones', :type => :list
-          property :subnet_group, 'DBSubnetGroupName'
-          property :vpc_security_group, 'VPCSecurityGroupIds', :type => :list
-
           property :replication_source_identifier, 'ReplicationSourceIdentifier'
-          property :cluster_parameter_group_name, 'DBClusterParameterGroupName'
+          property :snapshot_identifier, 'SnapshotIdentifier'
+          property :storage_encrypted, 'StorageEncrypted'
+
+          property :vpc_security_group, 'VPCSecurityGroupIds', :type => :list
 
           def render(*args)
             super.tap do |resource|
               render_tags(resource)
             end
           end
+
         end
+
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_rds_db_cluster.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_cluster.rb
@@ -44,13 +44,13 @@ module Convection
           property :engine, 'Engine'
           property :engine_version, 'EngineVersion'
           property :kms_key_id, 'KmsKeyId'
-          #only specify username and password  if you do not specify SnapshotIdentifier
+          # only specify username and password  if you do not specify SnapshotIdentifier
           property :master_username, 'MasterUsername'
           property :master_password, 'MasterUserPassword'
           property :port, 'Port'
-          #backup window must be in the format hh24:mi-hh24:mi, atleast 30 mins long, UTC, cannot conflict with maintenance window.
+          # backup window must be in the format hh24:mi-hh24:mi, atleast 30 mins long, UTC, cannot conflict with maintenance window.
           property :preferred_backup_window, 'PreferredBackupWindow'
-          #backup window must be in the format ddd:hh24:mi-ddd:hh24:mi, atleast 30 mins long, UTC, cannot conflict with backup window.
+          # backup window must be in the format ddd:hh24:mi-ddd:hh24:mi, atleast 30 mins long, UTC, cannot conflict with backup window.
           property :preferred_maintenance_window, 'PreferredMaintenanceWindow'
           property :replication_source_identifier, 'ReplicationSourceIdentifier'
           property :snapshot_identifier, 'SnapshotIdentifier'
@@ -63,9 +63,7 @@ module Convection
               render_tags(resource)
             end
           end
-
         end
-
       end
     end
   end

--- a/lib/convection/model/template/resource/aws_rds_db_cluster.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_cluster.rb
@@ -1,0 +1,51 @@
+require_relative '../resource'
+
+module Convection
+  module Model
+    class Template
+      class Resource
+        ##
+        # AWS::RDS::DBCluster
+        ##
+        class RDSDBCluster < Resource
+          include Model::Mixin::Taggable
+
+          type 'AWS::RDS::DBCluster', :rds_cluster
+
+          property :identifier, 'DBClusterIdentifier'
+          property :engine, 'Engine'
+          property :engine_version, 'EngineVersion'
+          property :storage_encrypted, 'StorageEncrypted'
+          property :port, 'Port'
+          property :backup_retention, 'BackupRetentionPeriod'
+          property :database_name, 'DatabaseName'
+
+          #only specify username and password  if you do not specify SnapshotIdentifier
+          property :master_username, 'MasterUsername'
+          property :master_password, 'MasterUserPassword'
+
+          property :kms_key_id, 'KmsKeyId'
+          property :snapshot_identifier, 'SnapshotIdentifier'
+
+          #backup window must be in the format hh24:mi-hh24:mi, atleast 30 mins long, UTC, cannot conflict with maintenance window.
+          property :preferred_backup_window, 'PreferredBackupWindow'
+          #backup window must be in the format ddd:hh24:mi-ddd:hh24:mi, atleast 30 mins long, UTC, cannot conflict with backup window.
+          property :preferred_maintenance_window, 'PreferredMaintenanceWindow'
+
+          property :availability_zone, 'AvailabilityZones', :type => :list
+          property :subnet_group, 'DBSubnetGroupName'
+          property :vpc_security_group, 'VPCSecurityGroupIds', :type => :list
+
+          property :replication_source_identifier, 'ReplicationSourceIdentifier'
+          property :cluster_parameter_group_name, 'DBClusterParameterGroupName'
+
+          def render(*args)
+            super.tap do |resource|
+              render_tags(resource)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource/aws_rds_db_instance.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_instance.rb
@@ -19,7 +19,6 @@ module Convection
           property :license_model, 'LicenseModel'
           property :storage_type, 'StorageType'
           property :storage_encrypted, 'StorageEncrypted'
-
           property :iops, 'Iops'
           property :port, 'Port'
           property :master, 'SourceDBInstanceIdentifier'

--- a/lib/convection/model/template/resource/aws_rds_db_instance.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_instance.rb
@@ -18,7 +18,6 @@ module Convection
           property :engine_version, 'EngineVersion'
           property :license_model, 'LicenseModel'
           property :storage_type, 'StorageType'
-          property :storage_encrypted, 'StorageEncrypted'
           property :iops, 'Iops'
           property :port, 'Port'
           property :master, 'SourceDBInstanceIdentifier'

--- a/lib/convection/model/template/resource/aws_rds_db_instance.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_instance.rb
@@ -18,6 +18,8 @@ module Convection
           property :engine_version, 'EngineVersion'
           property :license_model, 'LicenseModel'
           property :storage_type, 'StorageType'
+          property :storage_encrypted, 'StorageEncrypted'
+
           property :iops, 'Iops'
           property :port, 'Port'
           property :master, 'SourceDBInstanceIdentifier'

--- a/spec/convection/model/template/resource/aws_rds_db_cluster_spec.rb
+++ b/spec/convection/model/template/resource/aws_rds_db_cluster_spec.rb
@@ -5,32 +5,120 @@ class Convection::Model::Template::Resource
     let(:template) do
       Convection.template do
 
-        rds_db_cluster 'TestCluster' do
+        rds_cluster 'TestCluster' do
 
+          availability_zone 'us-east-1','us-east-2'
+          backup_retention 10
+          database_name 'test_database'
           identifier 'cluster1'
+          cluster_parameter_group_name 'default.aurora5.6'
+          subnet_group 'subnet_group'
           engine 'aurora'
           engine_version '5.6.10a'
-          storage_encrypted 'false'
-          port '3306'
-          backup_retention '10'
-          database_name 'test_database'
+          kms_key_id 'kms_key'
           master_username 'username'
           master_password 'password'
-          kms_key_id 'kms_key'
-          snapshot_identifier
+          port '3306'
           preferred_backup_window '12:30-01:30'
           preferred_maintenance_window 'mon:2:30-mon:3:30'
-          availability_zone 'us-east-1','us-east-2'
-          subnet_group 'subnet_group'
-          vpc_security_group 'test_security_group'
           replication_source_identifier 'source_instance'
-          cluster_parameter_group_name 'default.aurora5.6'
+          snapshot_identifier
+          storage_encrypted 'false'
           tag 'Name', 'Test'
+          vpc_security_group 'test_security_group_1' ,'test_security_group_2'
 
         end
-
-
       end
     end
+
+    subject do
+      template_json
+          .fetch('Resources')
+          .fetch('TestCluster')
+          .fetch('Properties')
+    end
+
+    it 'sets the DBClusterIdentifier' do
+      expect(subject['DBClusterIdentifier']).to eq('cluster1')
+    end
+
+    it 'sets the Engine' do
+      expect(subject['Engine']).to eq('aurora')
+    end
+
+    it 'sets the EngineVersion' do
+      expect(subject['EngineVersion']).to eq('5.6.10a')
+    end
+
+    it 'sets the StorageEncrypted' do
+      expect(subject['StorageEncrypted']).to eq('false')
+    end
+
+    it 'sets the Port' do
+      expect(subject['Port']).to eq('3306')
+    end
+
+    it 'sets the BackupRetentionPeriod' do
+      expect(subject['BackupRetentionPeriod']).to eq(10)
+    end
+
+    it 'sets the DatabaseName' do
+      expect(subject['DatabaseName']).to eq('test_database')
+    end
+
+    it 'sets the MasterUsername' do
+      expect(subject['MasterUsername']).to eq('username')
+    end
+
+    it 'sets the MasterUserPassword' do
+      expect(subject['MasterUserPassword']).to eq('password')
+    end
+
+    it 'sets the KmsKeyId' do
+      expect(subject['KmsKeyId']).to eq('kms_key')
+    end
+
+    it 'sets the PreferredBackupWindow' do
+      expect(subject['PreferredBackupWindow']).to eq('12:30-01:30')
+    end
+
+    it 'sets the PreferredMaintenanceWindow' do
+      expect(subject['PreferredMaintenanceWindow']).to eq('mon:2:30-mon:3:30')
+    end
+
+    it 'sets the AvailabilityZones' do
+      expect(subject['AvailabilityZones']).to match_array(['us-east-1','us-east-2'])
+    end
+
+    it 'sets the DBSubnetGroupName' do
+      expect(subject['DBSubnetGroupName']).to eq('subnet_group')
+    end
+
+    it 'sets the DBSubnetGroupName' do
+      expect(subject['DBSubnetGroupName']).to eq('subnet_group')
+    end
+
+    it 'sets the VPCSecurityGroupIds' do
+      expect(subject['VPCSecurityGroupIds']).to match_array(['test_security_group_1' ,'test_security_group_2'])
+    end
+
+    it 'sets the ReplicationSourceIdentifier' do
+      expect(subject['ReplicationSourceIdentifier']).to eq('source_instance')
+    end
+
+    it 'sets the DBClusterParameterGroupName' do
+      expect(subject['DBClusterParameterGroupName']).to eq('default.aurora5.6')
+    end
+
+    it 'sets tags' do
+      expect(subject['Tags']).to include(hash_including('Key' => 'Name', 'Value' => 'Test'))
+    end
+
+    private
+
+    def template_json
+      JSON.parse(template.to_json)
+    end
+
   end
 end

--- a/spec/convection/model/template/resource/aws_rds_db_cluster_spec.rb
+++ b/spec/convection/model/template/resource/aws_rds_db_cluster_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+class Convection::Model::Template::Resource
+  describe RDSDBCluster do
+    let(:template) do
+      Convection.template do
+
+        rds_db_cluster 'TestCluster' do
+
+          identifier 'cluster1'
+          engine 'aurora'
+          engine_version '5.6.10a'
+          storage_encrypted 'false'
+          port '3306'
+          backup_retention '10'
+          database_name 'test_database'
+          master_username 'username'
+          master_password 'password'
+          kms_key_id 'kms_key'
+          snapshot_identifier
+          preferred_backup_window '12:30-01:30'
+          preferred_maintenance_window 'mon:2:30-mon:3:30'
+          availability_zone 'us-east-1','us-east-2'
+          subnet_group 'subnet_group'
+          vpc_security_group 'test_security_group'
+          replication_source_identifier 'source_instance'
+          cluster_parameter_group_name 'default.aurora5.6'
+          tag 'Name', 'Test'
+
+        end
+
+
+      end
+    end
+  end
+end

--- a/spec/convection/model/template/resource/aws_rds_db_cluster_spec.rb
+++ b/spec/convection/model/template/resource/aws_rds_db_cluster_spec.rb
@@ -4,10 +4,8 @@ class Convection::Model::Template::Resource
   describe RDSDBCluster do
     let(:template) do
       Convection.template do
-
         rds_cluster 'TestCluster' do
-
-          availability_zone 'us-east-1','us-east-2'
+          availability_zone 'us-east-1', 'us-east-2'
           backup_retention 10
           database_name 'test_database'
           identifier 'cluster1'
@@ -25,17 +23,16 @@ class Convection::Model::Template::Resource
           snapshot_identifier
           storage_encrypted 'false'
           tag 'Name', 'Test'
-          vpc_security_group 'test_security_group_1' ,'test_security_group_2'
-
+          vpc_security_group 'test-security-group-1', 'test-security-group-2'
         end
       end
     end
 
     subject do
       template_json
-          .fetch('Resources')
-          .fetch('TestCluster')
-          .fetch('Properties')
+        .fetch('Resources')
+        .fetch('TestCluster')
+        .fetch('Properties')
     end
 
     it 'sets the DBClusterIdentifier' do
@@ -87,7 +84,7 @@ class Convection::Model::Template::Resource
     end
 
     it 'sets the AvailabilityZones' do
-      expect(subject['AvailabilityZones']).to match_array(['us-east-1','us-east-2'])
+      expect(subject['AvailabilityZones']).to match_array(['us-east-1', 'us-east-2'])
     end
 
     it 'sets the DBSubnetGroupName' do
@@ -99,7 +96,7 @@ class Convection::Model::Template::Resource
     end
 
     it 'sets the VPCSecurityGroupIds' do
-      expect(subject['VPCSecurityGroupIds']).to match_array(['test_security_group_1' ,'test_security_group_2'])
+      expect(subject['VPCSecurityGroupIds']).to match_array(['test-security-group-1', 'test-security-group-2'])
     end
 
     it 'sets the ReplicationSourceIdentifier' do
@@ -119,6 +116,5 @@ class Convection::Model::Template::Resource
     def template_json
       JSON.parse(template.to_json)
     end
-
   end
 end


### PR DESCRIPTION
# Description
Added support for creating AWS::RDS::DBCluster resource. 
Added an rspec test for the new resource. 

Tested by creating a database cluster in the dev account. 
