### PR TITLE
Removed a duplicated property in AWS::RDS::DBInstance resource. 

### DIFF
--- a/lib/convection/model/template/resource/aws_rds_db_instance.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_instance.rb
@@ -18,7 +18,6 @@ module Convection
           property :engine_version, 'EngineVersion'
           property :license_model, 'LicenseModel'
           property :storage_type, 'StorageType'
-          property :storage_encrypted, 'StorageEncrypted'
           property :iops, 'Iops'
           property :port, 'Port'
           property :master, 'SourceDBInstanceIdentifier'


### PR DESCRIPTION
A duplicate of the 'storage_encrypted' property was removed.