### PR TITLE
 Added support for AWS::RDS::DBClusterParameterGroup resource

### DIFF
--- a/lib/convection/model/template/resource/aws_rds_db_clusterparametergroup.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_clusterparametergroup.rb
@@ -1,0 +1,33 @@
+require_relative '../resource'
+
+module Convection
+  module Model
+    class Template
+      class Resource
+        ##
+        # AWS::RDS::DBClusterParameterGroup
+        #  rds_cluster_parameter_group 'DemoRDSClusterParameterGroup' do
+        #    description 'Sample Aurora Cluster Parameter Group'
+        #    family 'aurora5.6'
+        #    parameter 'time_zone', 'US/Eastern'
+        #    tag 'Name', 'Test'
+        #  end
+        ##
+        class RDSDBClusterParameterGroup < Resource
+          include Model::Mixin::Taggable
+
+          type 'AWS::RDS::DBClusterParameterGroup', :rds_cluster_parameter_group
+          property :description, 'Description'
+          property :family, 'Family'
+          property :parameter, 'Parameters', :type => :hash
+
+          def render(*args)
+            super.tap do |resource|
+              render_tags(resource)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/convection/model/template/resource/aws_rds_db__clusterparametergroup_spec.rb
+++ b/spec/convection/model/template/resource/aws_rds_db__clusterparametergroup_spec.rb
@@ -29,7 +29,7 @@ class Convection::Model::Template::Resource
     end
 
     it 'has Parameters' do
-      expect(subject['Parameters']).to eq({'time_zone'=>'US/Eastern'})
+      expect(subject['Parameters']).to eq('time_zone' => 'US/Eastern')
     end
 
     it 'sets tags' do

--- a/spec/convection/model/template/resource/aws_rds_db__clusterparametergroup_spec.rb
+++ b/spec/convection/model/template/resource/aws_rds_db__clusterparametergroup_spec.rb
@@ -5,9 +5,9 @@ class Convection::Model::Template::Resource
     let(:template) do
       Convection.template do
         rds_cluster_parameter_group 'DemoRDSClusterParameterGroup' do
-          description 'Describes cluster scaling'
+          description 'A sample parameter group'
           family 'aurora5.6'
-          parameter 'key1', 'value1'
+          parameter 'time_zone', 'US/Eastern'
           tag 'Name', 'Test'
         end
       end
@@ -21,7 +21,7 @@ class Convection::Model::Template::Resource
     end
 
     it 'sets the Description' do
-      expect(subject['Description']).to eq('Describes cluster scaling')
+      expect(subject['Description']).to eq('A sample parameter group')
     end
 
     it 'has a Family' do
@@ -29,7 +29,7 @@ class Convection::Model::Template::Resource
     end
 
     it 'has Parameters' do
-      expect(subject['Parameters']).to eq({'key1'=>'value1'})
+      expect(subject['Parameters']).to eq({'time_zone'=>'US/Eastern'})
     end
 
     it 'sets tags' do

--- a/spec/convection/model/template/resource/aws_rds_db__clusterparametergroup_spec.rb
+++ b/spec/convection/model/template/resource/aws_rds_db__clusterparametergroup_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+class Convection::Model::Template::Resource
+  describe RDSDBClusterParameterGroup do
+    let(:template) do
+      Convection.template do
+        rds_cluster_parameter_group 'DemoRDSClusterParameterGroup' do
+          description 'Describes cluster scaling'
+          family 'aurora5.6'
+          parameter 'key1', 'value1'
+          tag 'Name', 'Test'
+        end
+      end
+    end
+
+    subject do
+      template_json
+        .fetch('Resources')
+        .fetch('DemoRDSClusterParameterGroup')
+        .fetch('Properties')
+    end
+
+    it 'sets the Description' do
+      expect(subject['Description']).to eq('Describes cluster scaling')
+    end
+
+    it 'has a Family' do
+      expect(subject['Family']).to eq('aurora5.6')
+    end
+
+    it 'has Parameters' do
+      expect(subject['Parameters']).to eq({'key1'=>'value1'})
+    end
+
+    it 'sets tags' do
+      expect(subject['Tags']).to include(hash_including('Key' => 'Name', 'Value' => 'Test'))
+    end
+
+    private
+
+    def template_json
+      JSON.parse(template.to_json)
+    end
+  end
+end


### PR DESCRIPTION
 Added support for AWS::RDS::DBClusterParameterGroup resource.
Added a rspec test for the new resource. 
Tested by creating a DB Cluster Parameter group  in the dev account.