### PR TITLE
Added property for DBClusterIdentifier in AWS::RDS::DBInstance resource.

### DIFF
--- a/lib/convection/model/template/resource/aws_rds_db_instance.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_instance.rb
@@ -22,6 +22,7 @@ module Convection
           property :iops, 'Iops'
           property :port, 'Port'
           property :master, 'SourceDBInstanceIdentifier'
+          property :db_cluster_identifier, 'DBClusterIdentifier'
 
           property :database_name, 'DBName'
           property :master_username, 'MasterUsername'


### PR DESCRIPTION
Added a property 'db_cluster_identifier' for DBClusterIdentifier in the rds database instance resource. 