### PR TITLE
Fixed typo in VpcSecurityGroupIds property

### DIFF
--- a/lib/convection/model/template/resource/aws_rds_db_cluster.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_cluster.rb
@@ -56,7 +56,7 @@ module Convection
           property :snapshot_identifier, 'SnapshotIdentifier'
           property :storage_encrypted, 'StorageEncrypted'
 
-          property :vpc_security_group, 'VPCSecurityGroupIds', :type => :list
+          property :vpc_security_group, 'VpcSecurityGroupIds', :type => :list
 
           def render(*args)
             super.tap do |resource|

--- a/spec/convection/model/template/resource/aws_rds_db_cluster_spec.rb
+++ b/spec/convection/model/template/resource/aws_rds_db_cluster_spec.rb
@@ -95,8 +95,8 @@ class Convection::Model::Template::Resource
       expect(subject['DBSubnetGroupName']).to eq('subnet_group')
     end
 
-    it 'sets the VPCSecurityGroupIds' do
-      expect(subject['VPCSecurityGroupIds']).to match_array(['test-security-group-1', 'test-security-group-2'])
+    it 'sets the VpcSecurityGroupIds' do
+      expect(subject['VpcSecurityGroupIds']).to match_array(['test-security-group-1', 'test-security-group-2'])
     end
 
     it 'sets the ReplicationSourceIdentifier' do


### PR DESCRIPTION
VpcSecurityGroupsIds property had been mistyped as VPCSecurityGroupsIds. 