### PR TITLE
Add more properties to Lambda and make it taggable

### DIFF
--- a/lib/convection/model/template/resource/aws_lambda_function.rb
+++ b/lib/convection/model/template/resource/aws_lambda_function.rb
@@ -8,6 +8,8 @@ module Convection
         # AWS::Lambda::Function
         ##
         class Lambda < Resource
+          include Model::Mixin::Taggable
+
           type 'AWS::Lambda::Function'
           property :function_name, 'FunctionName'
           property :description, 'Description'
@@ -16,10 +18,12 @@ module Convection
           property :runtime, 'Runtime'
           property :timeout, 'Timeout'
           property :role, 'Role'
+          property :kms_key_arn, 'KmsKeyArn'
           # psuedo-property definitions. We add the expected name as a nested DSL for these below.
           property :env, 'Environment'
           property :function_code, 'Code'
           property :vpc_cfg, 'VpcConfig'
+          property :dead_letter_cfg, 'DeadLetterConfig'
 
           # Add code block
           def code(&block)
@@ -39,6 +43,12 @@ module Convection
             vpc_cfg = ResourceProperty::LambdaVpcConfig.new(self)
             vpc_cfg.instance_exec(&block) if block
             properties['VpcConfig'].set(vpc_cfg)
+          end
+
+          def dead_letter_config(&block)
+            env = ResourceProperty::LambdaDeadLetterConfig.new(self)
+            env.instance_exec(&block) if block
+            properties['DeadLetterConfig'].set(dead_letter_cfg)
           end
         end
       end

--- a/lib/convection/model/template/resource/aws_lambda_function.rb
+++ b/lib/convection/model/template/resource/aws_lambda_function.rb
@@ -46,7 +46,7 @@ module Convection
           end
 
           def dead_letter_config(&block)
-            env = ResourceProperty::LambdaDeadLetterConfig.new(self)
+            env = ResourceProperty::LambdaFunctionDeadLetterConfig.new(self)
             env.instance_exec(&block) if block
             properties['DeadLetterConfig'].set(dead_letter_cfg)
           end

--- a/lib/convection/model/template/resource/aws_lambda_function.rb
+++ b/lib/convection/model/template/resource/aws_lambda_function.rb
@@ -19,6 +19,7 @@ module Convection
           property :timeout, 'Timeout'
           property :role, 'Role'
           property :kms_key_arn, 'KmsKeyArn'
+          property :concurrency, 'ReservedConcurrentExecutions'
           # psuedo-property definitions. We add the expected name as a nested DSL for these below.
           property :env, 'Environment'
           property :function_code, 'Code'

--- a/lib/convection/model/template/resource_property/aws_lambda_dead_letter_config.rb
+++ b/lib/convection/model/template/resource_property/aws_lambda_dead_letter_config.rb
@@ -1,0 +1,15 @@
+require_relative '../resource_property'
+
+module Convection
+  module Model
+    class Template
+      class ResourceProperty
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-deadletterconfig.html
+        # Lambda Function DeadLetterConfig}
+        class LambdaDeadLetterConfig < ResourceProperty
+          property :target_arn, 'TargetArn'
+        end
+      end
+    end
+  end
+end

--- a/lib/convection/model/template/resource_property/aws_lambda_environment.rb
+++ b/lib/convection/model/template/resource_property/aws_lambda_environment.rb
@@ -4,7 +4,7 @@ module Convection
   module Model
     class Template
       class ResourceProperty
-        # Represents an {http://docs.aws.amazon.com/lambda/latest/dg/API_Environment.html}
+        # Represents an {https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html}
         class LambdaEnvironment < ResourceProperty
           property :variables, 'Variables'
         end

--- a/lib/convection/model/template/resource_property/aws_lambda_function_dead_letter_config.rb
+++ b/lib/convection/model/template/resource_property/aws_lambda_function_dead_letter_config.rb
@@ -4,8 +4,7 @@ module Convection
   module Model
     class Template
       class ResourceProperty
-        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-deadletterconfig.html
-        # Lambda Function DeadLetterConfig}
+        # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-deadletterconfig.html}
         class LambdaFunctionDeadLetterConfig < ResourceProperty
           property :target_arn, 'TargetArn'
         end

--- a/lib/convection/model/template/resource_property/aws_lambda_function_dead_letter_config.rb
+++ b/lib/convection/model/template/resource_property/aws_lambda_function_dead_letter_config.rb
@@ -6,7 +6,7 @@ module Convection
       class ResourceProperty
         # Represents an {http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-deadletterconfig.html
         # Lambda Function DeadLetterConfig}
-        class LambdaDeadLetterConfig < ResourceProperty
+        class LambdaFunctionDeadLetterConfig < ResourceProperty
           property :target_arn, 'TargetArn'
         end
       end


### PR DESCRIPTION
<!-- Remove any sections that do not apply to your changes. HTML comments are ignored. -->
# Description
<!-- Describe your changes here. -->
<!-- Include references to relevant pull requests/commits here. -->
<!-- * Did you update documentation? -->
<!-- * Did you update test coverage? -->
Add KmsKeyArn for environment variable encryption.
Add DeadLetterConfig for failure DeadLetterQueue use. (#256)
Add Taggable mixin to allow tags on lambdas.
Add ReservedConcurrentExecutions to set max concurrent executions.

# Motivation and Context
<!-- Describe the use case that requires your changes. -->
I want to use tags and decided to fill in the other missing bits as well.

This is an updated version of #263	

# Usage Examples
<!-- Code or screenshot examples of using your feature, if applicable. -->
```ruby
lambda_function 'MyLambda' do
  handler 'lambda.handler'
  runtime 'python2.7'
  timeout 30
  memory_size 128
  kms_key_arn get_att('MyKmsKey', 'Arn')
  concurrency 100

  dead_letter_config do
    target_arn get_att('MyDeadLetterQueue', 'Arn')
  end

  tag 'my_first_tag_key', 'tag_value'
  tag 'my_second_tag_key, 'other_tag_value'
end
```

Of course you can use raw strings as well:
```ruby
kms_key_arn 'arn:aws:kms:us-east-1:XXXXXXXXXXXX:key/my-alias-or-uuid'

dead_letter_config do
  target_arn 'arn:aws:sqs:us-east-1:XXXXXXXXXXXX:my-queue-name'
end
```
# Testing Steps
<!-- List any steps required to test your changes. -->
todo
