### PR TITLE
Fix dead letter config for lambda function

### DIFF
--- a/lib/convection/model/template/resource/aws_lambda_function.rb
+++ b/lib/convection/model/template/resource/aws_lambda_function.rb
@@ -47,8 +47,8 @@ module Convection
           end
 
           def dead_letter_config(&block)
-            env = ResourceProperty::LambdaFunctionDeadLetterConfig.new(self)
-            env.instance_exec(&block) if block
+            dead_letter_cfg = ResourceProperty::LambdaFunctionDeadLetterConfig.new(self)
+            dead_letter_cfg.instance_exec(&block) if block
             properties['DeadLetterConfig'].set(dead_letter_cfg)
           end
         end

--- a/lib/convection/model/template/resource/aws_lambda_function.rb
+++ b/lib/convection/model/template/resource/aws_lambda_function.rb
@@ -51,6 +51,12 @@ module Convection
             dead_letter_cfg.instance_exec(&block) if block
             properties['DeadLetterConfig'].set(dead_letter_cfg)
           end
+
+          def render(*args)
+            super.tap do |resource|
+              render_tags(resource)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
<!-- Remove any sections that do not apply to your changes. HTML comments are ignored. -->
# Description
<!-- Describe your changes here. -->
<!-- Include references to relevant pull requests/commits here. -->
<!-- * Did you update documentation? -->
<!-- * Did you update test coverage? -->
Replace `env` with `dead_letter_cfg` in the DeadLetterConfig block.

# Motivation and Context
<!-- Describe the use case that requires your changes. -->
I noticed after the fact that `env` being referenced still, so the new `dead_letter_cfg` never gets used. 😞 
