### PR TITLE
PD-17965: Add filterpolicy property sns subscription

### DIFF
--- a/lib/convection/model/template/resource/aws_sns_subscription.rb
+++ b/lib/convection/model/template/resource/aws_sns_subscription.rb
@@ -9,12 +9,14 @@ module Convection
         #     endpoint 'failures@example.com'
         #     protocol 'email'
         #     topic_arn 'arn:aws:sns:us-west-2:123456789012:example-topic'
+        #     filter_policy 'Type' => 'Notification', 'MessageId' => 'e3c4e17a-819b-5d95-a0e8-b306c25afda0', 'MessageAttributes' => [{' AttributeName' => 'Name', 'KeyType' => 'HASH' }],
         #   end
         class SNSSubscription < Resource
           type 'AWS::SNS::Subscription'
           property :endpoint, 'Endpoint'
           property :protocol, 'Protocol'
           property :topic_arn, 'TopicArn'
+          property :filter_policy, 'FilterPolicy'
         end
       end
     end

--- a/spec/convection/model/template/resource/aws_sns_subscription_spec.rb
+++ b/spec/convection/model/template/resource/aws_sns_subscription_spec.rb
@@ -8,6 +8,7 @@ class Convection::Model::Template::Resource
           endpoint 'failures@example.com'
           protocol 'email'
           topic_arn 'arn:aws:sns:us-west-2:123456789012:example-topic'
+          filter_policy 'Type' => 'Notification', 'MessageId' => 'e3c4e17a-819b-5d95-a0e8-b306c25afda0', 'MessageAttributes' => { 'AttributeName' => 'Name', 'KeyType' => 'HASH' }
         end
       end
     end
@@ -30,6 +31,13 @@ class Convection::Model::Template::Resource
     it 'sets the TopicArn' do
       expect(subject['TopicArn']).to eq('arn:aws:sns:us-west-2:123456789012:example-topic')
     end
+
+    it 'sets the FilterPolicy' do
+      expect(subject['FilterPolicy']).to include('Type' => 'Notification',
+                                                                'MessageId' => 'e3c4e17a-819b-5d95-a0e8-b306c25afda0',
+                                                                'MessageAttributes' => { 'AttributeName' => 'Name', 'KeyType' => 'HASH' })
+    end
+
 
     private
 


### PR DESCRIPTION
Adds support for FilterPolicy property for AWS::SNS::Subscription resource. 