### PR TITLE
Adding retain highlight to output for deletionpolicy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,11 @@ Metrics/LineLength:
   Exclude:
     - 'lib/convection/dsl/terraform_intrinsic_functions.rb'
 
+# Ignore block length limits for DSLs
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'
+
 # AbcSize:
 #   Max: 24
 # ClassLength:

--- a/lib/convection/model/diff.rb
+++ b/lib/convection/model/diff.rb
@@ -45,6 +45,13 @@ module Convection
 
         [action, message, color]
       end
+
+      def ==(other)
+        @key == other.key &&
+          @ours == other.ours &&
+          @theirs == other.theirs &&
+          @action == other.action
+      end
     end
   end
 end

--- a/lib/convection/model/diff.rb
+++ b/lib/convection/model/diff.rb
@@ -10,10 +10,10 @@ module Convection
       extend Mixin::Colorize
 
       attr_reader :key
-      attr_reader :action
+      attr_accessor :action
       attr_reader :ours
       attr_reader :theirs
-      colorize :action, :green => [:create], :yellow => [:update], :red => [:delete, :replace]
+      colorize :action, :green => [:create], :yellow => [:update, :retain], :red => [:delete, :replace]
 
       def initialize(key, ours, theirs)
         @key = key
@@ -40,6 +40,7 @@ module Convection
                   when :update then "#{ key }: #{ theirs } => #{ ours }"
                   when :replace then "#{ key }: #{ theirs } => #{ ours }"
                   when :delete then key
+                  when :retain then key
                   end
 
         [action, message, color]

--- a/lib/convection/model/diff.rb
+++ b/lib/convection/model/diff.rb
@@ -7,6 +7,7 @@ module Convection
     # Difference between an item in two templates
     ##
     class Diff
+      include Comparable
       extend Mixin::Colorize
 
       attr_reader :key
@@ -46,11 +47,17 @@ module Convection
         [action, message, color]
       end
 
-      def ==(other)
-        @key == other.key &&
-          @ours == other.ours &&
-          @theirs == other.theirs &&
-          @action == other.action
+      def <=>(other)
+        value = @key <=> other.key
+        return value if value != 0
+
+        value = @ours <=> other.ours
+        return value if value != 0
+
+        value = @theirs <=> other.theirs
+        return value if value != 0
+
+        @action <=> other.action
       end
     end
   end

--- a/lib/convection/model/template.rb
+++ b/lib/convection/model/template.rb
@@ -310,7 +310,7 @@ module Convection
         # us-east-1       delete  Resources.sgtestConvectionDeletion.Properties.AWS::EC2::SecurityGroup.VpcId
         #
         events = render(stack_, retain: retain).diff(other).map { |diff| Diff.new(diff[0], *diff[1]) }
-        retained_resources = events.select { |event| event.key.ends_with?('DeletionPolicy') && event.theirs == 'Retain' }
+        retained_resources = events.select { |event| event.key.end_with?('DeletionPolicy') && event.theirs == 'Retain' }
 
         retained_resources.map! { |resource| resource.key.split('DeletionPolicy').first }
         retained_resources.keep_if do |name|
@@ -321,7 +321,7 @@ module Convection
 
         events.each do |event|
           retained = false
-          retained_resources.each do |resource|
+          retained_resources.any? do |resource|
             if event.key.starts_with?(resource) && event.action == :delete
               retained = true
               break

--- a/lib/convection/model/template.rb
+++ b/lib/convection/model/template.rb
@@ -309,10 +309,12 @@ module Convection
         # us-east-1       delete  Resources.sgtestConvectionDeletion.Properties.AWS::EC2::SecurityGroup.GroupDescription
         # us-east-1       delete  Resources.sgtestConvectionDeletion.Properties.AWS::EC2::SecurityGroup.VpcId
         #
-        events = render(stack_, retain: retain).diff(other).map { |diff| Diff.new(diff[0], *diff[1]) }
-        retained_resources = events.select { |event| event.key.end_with?('DeletionPolicy') && event.theirs == 'Retain' }
+        suffix = '.DeletionPolicy'.freeze
 
-        retained_resources.map! { |resource| resource.key.split('DeletionPolicy').first }
+        events = render(stack_, retain: retain).diff(other).map { |diff| Diff.new(diff[0], *diff[1]) }
+        retained_resources = events.select { |event| event.key.end_with?(suffix) && event.theirs == 'Retain' }
+
+        retained_resources.map! { |resource| resource.key[0...-suffix.length] }
         retained_resources.keep_if do |name|
           events.any? do |event|
             event.action == :delete && event.key == name

--- a/lib/convection/model/template.rb
+++ b/lib/convection/model/template.rb
@@ -326,9 +326,7 @@ module Convection
           retained = retained_resources.any? do |resource|
             event.action == :delete && event.key.start_with?(resource)
           end
-          if retained
-            event.action = :retain
-          end
+          event.action = :retain if retained
         end
 
         events

--- a/lib/convection/model/template.rb
+++ b/lib/convection/model/template.rb
@@ -281,7 +281,6 @@ module Convection
           'Conditions' => conditions.map(&:render),
           'Resources' => all_resources.map do |resource|
             if retain && resource.deletion_policy.nil?
-              puts "If you forget to set this in the template, you will get a false retain on next run"
               resource.deletion_policy('Retain')
             end
             resource.render

--- a/spec/convection/model/template/template_spec.rb
+++ b/spec/convection/model/template/template_spec.rb
@@ -120,6 +120,32 @@ class Convection::Model::Template
           expect(events).to eq(deleted)
         end
 
+        it 'emits delete events when properties are deleted and resources are retained' do
+          local = Convection.template do
+            resource 'TestInstance' do
+              type 'TestResource'
+              deletion_policy 'Retain'
+            end
+          end
+
+          remote = Convection.template do
+            resource 'TestInstance' do
+              type 'TestResource'
+              property 'Key', 'Value'
+              deletion_policy 'Retain'
+            end
+          end
+
+          deleted = [Convection::Model::Diff.new('Resources.TestInstance.Properties.TestResource.Key', nil, 'Value')]
+          deleted.each { |event| event.action = :delete }
+          deleted.sort!
+
+          events = local.diff(remote.render)
+          events.sort!
+
+          expect(events).to eq(deleted)
+        end
+
         it 'only checks for DeletionPolicy events' do
           local = Convection.template do
           end

--- a/spec/convection/model/template/template_spec.rb
+++ b/spec/convection/model/template/template_spec.rb
@@ -49,6 +49,28 @@ class Convection::Model::Template
       end
     end
 
+    describe '#diff' do
+      context 'when diffing resources with delete_policy' do
+        it 'emits create events when a delete_policy is added' do
+          local = Convection.template do
+            resource 'TestInstance' do
+              deletion_policy 'Retain'
+            end
+          end
+
+          remote = Convection.template do
+            resource 'TestInstance' do
+            end
+          end
+
+          created = [Convection::Model::Diff.new('Resources.TestInstance.DeletionPolicy', 'Retain', nil)]
+
+          events = local.diff(remote.render)
+          expect(events).to eq(created)
+        end
+      end
+    end
+
     subject do
       template_json
     end

--- a/spec/convection/model/template/template_spec.rb
+++ b/spec/convection/model/template/template_spec.rb
@@ -95,6 +95,30 @@ class Convection::Model::Template
 
           expect(events).to eq(retained)
         end
+
+        it 'emits delete events when a deletion_policy is removed' do
+          local = Convection.template do
+            resource 'TestInstance' do
+              type 'TestResource'
+            end
+          end
+
+          remote = Convection.template do
+            resource 'TestInstance' do
+              type 'TestResource'
+              deletion_policy 'Retain'
+            end
+          end
+
+          deleted = [Convection::Model::Diff.new('Resources.TestInstance.DeletionPolicy', nil, 'Retain')]
+          deleted.each { |event| event.action = :delete }
+          deleted.sort!
+
+          events = local.diff(remote.render)
+          events.sort!
+
+          expect(events).to eq(deleted)
+        end
       end
     end
 


### PR DESCRIPTION
<!-- Remove any sections that do not apply to your changes. HTML comments are ignored. -->
# Description
This makes it clear when a DeletionPolicy is set to Retain, which resources will be kept.
<!-- Describe your changes here. -->
<!-- Include references to relevant pull requests/commits here. -->
<!-- * Did you update documentation? -->
<!-- * Did you update test coverage? -->

# Motivation and Context
We are starting to migrate the last of our convection work to terraform and want it to be clear when resources are kept.
<!-- Describe the use case that requires your changes. -->

