### PR TITLE
Adds RDSDBInstance deletion protection property

### DIFF
--- a/lib/convection/model/template/resource/aws_rds_db_instance.rb
+++ b/lib/convection/model/template/resource/aws_rds_db_instance.rb
@@ -39,6 +39,7 @@ module Convection
           property :backup_retention_period, 'BackupRetentionPeriod'
           property :preferred_backup_window, 'PreferredBackupWindow'
           property :preferred_maintenance_window, 'PreferredMaintenanceWindow'
+          property :deletion_protection, 'DeletionProtection'
 
           property :availability_zone, 'AvailabilityZone'
           property :multi_az, 'MultiAZ'


### PR DESCRIPTION
As per CloudFormation docs: 
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-deletionprotection
